### PR TITLE
Deployment: Always resolve internal hosts with `dig`.

### DIFF
--- a/machines/ml/main.tf
+++ b/machines/ml/main.tf
@@ -132,7 +132,7 @@ resource "aws_volume_attachment" "controller-cache-attachment" {
   skip_destroy = true
 
   provisioner "local-exec" {
-    command = "../../scripts/run-ansible-playbook-on-host ../../services/controller/src/plz/controller/startup/startup.yml ${aws_instance.controller.private_ip} /dev/stdin <<< 'device: /dev/xvdx'"
+    command = "../../scripts/run-ansible-playbook-on-host ../../services/controller/src/plz/controller/startup/startup.yml ${aws_instance.controller.private_dns} /dev/stdin <<< 'device: /dev/xvdx'"
   }
 }
 

--- a/scripts/run-ansible-playbook-on-host
+++ b/scripts/run-ansible-playbook-on-host
@@ -7,7 +7,7 @@ set -o pipefail
 ROOT=${0:a:h:h}
 
 PLAYBOOK=${1:a}
-HOST=$2
+HOSTNAME=$2
 shift
 shift
 
@@ -19,6 +19,12 @@ done
 
 eval $(make --no-print-directory --file="${ROOT}/vars.mk" bash)
 
+HOST_IP=$(dig +short $HOSTNAME)
+if [[ -z $HOST_IP ]]; then
+  echo >&2 "Could not resolve ${HOSTNAME}."
+  exit 1
+fi
+
 SSH_PRIVATE_KEY_FILE="${ROOT}/machines/keys/plz.privkey"
 
 ANSIBLE_INVENTORY=$(mktemp "${TMPDIR:-/tmp/}inventory-XXXXX")
@@ -26,7 +32,7 @@ cat > $ANSIBLE_INVENTORY <<EOF
 ---
 all:
   hosts:
-    ${HOST}:
+    ${HOST_IP}:
       ansible_user: "ubuntu"
       ansible_ssh_private_key_file: "${SSH_PRIVATE_KEY_FILE}"
       ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"


### PR DESCRIPTION
At least on macOS, `dig` doesn't use the OS DNS cache, which can get
stale because for some reason, it doesn't respect the TTL.

This affects both volume mounting and controller deployment.