### PR TITLE
Make the tests faster by speeding up Docker builds.

### DIFF
--- a/cli/.dockerignore
+++ b/cli/.dockerignore
@@ -1,4 +1,4 @@
-__pycache__
+**/*.egg-info
+**/__pycache__
 build
 dist
-*.egg-info

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM python:3-slim
+FROM python:3-slim as builder
 
 RUN mkdir -p /src
 WORKDIR /src
@@ -11,7 +11,7 @@ RUN python setup.py bdist_wheel
 # Run
 FROM python:3.6
 
-COPY --from=0 /src/dist/plz_cli-0.1.0-py3-none-any.whl /tmp/
+COPY --from=builder /src/dist/plz_cli-0.1.0-py3-none-any.whl /tmp/
 RUN pip install /tmp/plz_cli-0.1.0-py3-none-any.whl
 
 ENV PYTHONUNBUFFERED 1

--- a/cli/src/plz/cli/log.py
+++ b/cli/src/plz/cli/log.py
@@ -1,6 +1,10 @@
 import sys
 
 
+def log_debug(message):
+    print('::', message)
+
+
 def log_info(message):
     if sys.stdout.isatty():
         print('\x1b[33m', end='')

--- a/cli/src/plz/cli/run_execution_operation.py
+++ b/cli/src/plz/cli/run_execution_operation.py
@@ -65,12 +65,12 @@ class RunExecutionOperation(Operation):
 
         params = parameters.parse_file(self.parameters_file)
 
-        build_context = self.suboperation(
+        with self.suboperation(
                 'Capturing the context',
-                self.capture_build_context)
-        snapshot_id = self.suboperation(
-                'Building the program snapshot',
-                lambda: self.submit_context_for_building(build_context))
+                self.capture_build_context) as build_context:
+            snapshot_id = self.suboperation(
+                    'Building the program snapshot',
+                    lambda: self.submit_context_for_building(build_context))
         input_id = self.suboperation(
                 'Capturing the input',
                 self.capture_input,
@@ -117,7 +117,7 @@ class RunExecutionOperation(Operation):
                 f'Execution failed with an exit status of {status.code}.',
                 exit_code=status.code)
 
-    def capture_build_context(self):
+    def capture_build_context(self) -> io.FileIO:
         context_dir = os.getcwd()
         dockerfile_path = os.path.join(context_dir, 'Dockerfile')
         dockerfile_created = False
@@ -146,7 +146,7 @@ class RunExecutionOperation(Operation):
                 os.remove(dockerfile_path)
         return build_context
 
-    def submit_context_for_building(self, build_context) -> str:
+    def submit_context_for_building(self, build_context: io.FileIO) -> str:
         metadata = {
             'user': self.configuration.user,
             'project': self.configuration.project,

--- a/services/controller/.dockerignore
+++ b/services/controller/.dockerignore
@@ -1,1 +1,1 @@
-env
+**/__pycache__

--- a/services/controller/Dockerfile
+++ b/services/controller/Dockerfile
@@ -19,9 +19,9 @@ WORKDIR /src
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --system --deploy
 
-COPY run ./
 COPY src ./src/
+COPY run ./
 
-HEALTHCHECK CMD curl -f http://localhost/
+HEALTHCHECK --interval=5s CMD curl -f http://localhost/
 
 ENTRYPOINT ["/tini", "--", "./run"]

--- a/services/controller/Pipfile
+++ b/services/controller/Pipfile
@@ -14,7 +14,6 @@ gunicorn = "*"
 pyhocon = "*"
 redis = "*"
 requests = "*"
-requests-unixsocket = "*"
 
 [dev-packages]
 "flake8" = "*"

--- a/services/controller/Pipfile
+++ b/services/controller/Pipfile
@@ -14,6 +14,7 @@ gunicorn = "*"
 pyhocon = "*"
 redis = "*"
 requests = "*"
+requests-unixsocket = "*"
 
 [dev-packages]
 "flake8" = "*"

--- a/services/controller/Pipfile.lock
+++ b/services/controller/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e83d03d695261be60cc621727e2e60ea845b7b8fabab3d1bf76e28e664c12011"
+            "sha256": "5be5e0fad65cdc2faef107820b5dfd3fc4f9b2b66d95f7dd35f6755a9e1ab006"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -165,13 +165,6 @@
             ],
             "index": "pypi",
             "version": "==2.18.4"
-        },
-        "requests-unixsocket": {
-            "hashes": [
-                "sha256:a91bc0138f61fb3396de6358fa81e2cd069a150ade5111f869df01d8bc9d294c"
-            ],
-            "index": "pypi",
-            "version": "==0.1.5"
         },
         "s3transfer": {
             "hashes": [

--- a/services/controller/Pipfile.lock
+++ b/services/controller/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5be5e0fad65cdc2faef107820b5dfd3fc4f9b2b66d95f7dd35f6755a9e1ab006"
+            "sha256": "e83d03d695261be60cc621727e2e60ea845b7b8fabab3d1bf76e28e664c12011"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,25 +18,25 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:4c746d55fb6294c11e78db76648c7f321f8068dc5ab402456b5e3e4ee52423b9",
-                "sha256:5c02372447e07bd67f7c19624642dcf5c7aabe126e1c44ff4ad241aeb97fc729"
+                "sha256:13ad5f64a247d655a27dca83274588e9d14cba61b38d3d4fd2b011b7197d88dd",
+                "sha256:a56b21efbc994580fc9cef454f0f949745c152326f939aed6609d1c47b2a0f8f"
             ],
             "index": "pypi",
-            "version": "==1.7.2"
+            "version": "==1.7.4"
         },
         "botocore": {
             "hashes": [
-                "sha256:27945af4bfb2a1ff1f11c730d24b84da6e1f40465907029e8980903f3b984070",
-                "sha256:8ded801591ef5df04244dc1ba2496dd04a9abbd165d0d2ad501b6cd4b34946d4"
+                "sha256:5602738392ecde5c02a06a3b02de07171f440a44cdfef0aadff4b59567359607",
+                "sha256:77f2869b8c27afbab78b72ce6b74c75923421f364c7a0153ac1a38858c59cd91"
             ],
-            "version": "==1.10.2"
+            "version": "==1.10.4"
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
@@ -166,6 +166,13 @@
             "index": "pypi",
             "version": "==2.18.4"
         },
+        "requests-unixsocket": {
+            "hashes": [
+                "sha256:a91bc0138f61fb3396de6358fa81e2cd069a150ade5111f869df01d8bc9d294c"
+            ],
+            "index": "pypi",
+            "version": "==0.1.5"
+        },
         "s3transfer": {
             "hashes": [
                 "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
@@ -220,6 +227,8 @@
         },
         "pycodestyle": {
             "hashes": [
+                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
+                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],

--- a/services/controller/src/plz/controller/configuration.py
+++ b/services/controller/src/plz/controller/configuration.py
@@ -89,7 +89,7 @@ def _images_from(config, docker_host):
     docker_api_client = docker.APIClient(base_url=docker_host)
     if images_type == 'local':
         repository = config.get('images.repository', 'plz/builds')
-        images = LocalImages(docker_host, docker_api_client, repository)
+        images = LocalImages(docker_api_client, repository)
     elif images_type == 'aws-ecr':
         ecr_client = boto3.client(
             service_name='ecr',

--- a/services/controller/src/plz/controller/configuration.py
+++ b/services/controller/src/plz/controller/configuration.py
@@ -89,7 +89,7 @@ def _images_from(config, docker_host):
     docker_api_client = docker.APIClient(base_url=docker_host)
     if images_type == 'local':
         repository = config.get('images.repository', 'plz/builds')
-        images = LocalImages(docker_api_client, repository)
+        images = LocalImages(docker_host, docker_api_client, repository)
     elif images_type == 'aws-ecr':
         ecr_client = boto3.client(
             service_name='ecr',

--- a/services/controller/src/plz/controller/configuration.py
+++ b/services/controller/src/plz/controller/configuration.py
@@ -29,7 +29,7 @@ def load() -> pyhocon.ConfigTree:
     try:
         start = sys.argv.index('--') + 1
     except ValueError:
-        start = 0
+        start = 1
     args = sys.argv[start:]
     if len(args) == 1:
         return load_from_file(args[0])

--- a/services/controller/src/plz/controller/images/local.py
+++ b/services/controller/src/plz/controller/images/local.py
@@ -14,9 +14,13 @@ class LocalImages(Images):
         """
         Builds an image from the tarball supplied as ``attr:fileobj``.
 
-        We used to use the Docker client to build the image, but for some
-        reason it's much slower, with a minimum of 5 seconds to build anything
-        under testing. Going direct seems to be much faster.
+        We used to use `docker_api_client.build` to build the image, but it's
+        much slower, with a minimum of 5 seconds to build anything under
+        testing. Turns out that it takes _ages_ to figure out authentication
+        for building/pulling, which sucks.
+
+        At some point, let's send them a patch upstream. Until then, sending a
+        request directly to Docker over HTTP works.
         """
         tag = f'{self.repository}:{tag}'
         return self.docker_api_client.post(

--- a/services/controller/src/plz/controller/images/local.py
+++ b/services/controller/src/plz/controller/images/local.py
@@ -15,9 +15,9 @@ class LocalImages(Images):
         Builds an image from the tarball supplied as ``attr:fileobj``.
 
         We used to use `docker_api_client.build` to build the image, but it's
-        much slower, with a minimum of 5 seconds to build anything under
-        testing. Turns out that it takes _ages_ to figure out authentication
-        for building/pulling, which sucks.
+        much slower. This is because it captures all the authentication
+        information for building/pulling, which is useful but not necessary for
+        us right now.
 
         At some point, let's send them a patch upstream. Until then, sending a
         request directly to Docker over HTTP works.

--- a/services/controller/src/plz/controller/images/local.py
+++ b/services/controller/src/plz/controller/images/local.py
@@ -1,22 +1,46 @@
 from typing import BinaryIO, Iterator
 
 import docker
+import docker.utils
+import requests
+import requests_unixsocket
 
 from plz.controller.images.images_base import Images
 
 
 class LocalImages(Images):
-    def __init__(self, docker_api_client: docker.APIClient, repository: str):
+    def __init__(self,
+                 docker_host: str,
+                 docker_api_client: docker.APIClient,
+                 repository: str):
         super().__init__(repository)
+        if not docker_host:
+            self.docker_host = 'http+unix://%2Fvar%2Frun%2Fdocker.sock'
+        else:
+            self.docker_host = docker.utils.parse_host(docker_host)
         self.docker_api_client = docker_api_client
 
     def build(self, fileobj: BinaryIO, tag: str) -> Iterator[str]:
-        return self.docker_api_client.build(
-            fileobj=fileobj,
-            custom_context=True,
-            encoding='bz2',
-            rm=True,
-            tag=f'{self.repository}:{tag}')
+        """
+        Builds an image from the tarball supplied as ``attr:fileobj``.
+
+        We used to use the Docker client to build the image, but for some
+        reason it's much slower, with a minimum of 5 seconds to build anything
+        under testing. Going direct seems to be much faster.
+        """
+        tag = f'{self.repository}:{tag}'
+        with requests_unixsocket.monkeypatch():
+            return requests.post(
+                self.docker_host + '/build',
+                params={
+                    't': tag,
+                },
+                headers={
+                    'Content-Type': 'application/tar',
+                    'Content-Encoding': 'bz2',
+                },
+                data=fileobj,
+            )
 
     def for_host(self, docker_url: str) -> 'LocalImages':
         new_docker_api_client = docker.APIClient(base_url=docker_url)

--- a/services/controller/src/plz/controller/images/local.py
+++ b/services/controller/src/plz/controller/images/local.py
@@ -1,23 +1,13 @@
 from typing import BinaryIO, Iterator
 
 import docker
-import docker.utils
-import requests
-import requests_unixsocket
 
 from plz.controller.images.images_base import Images
 
 
 class LocalImages(Images):
-    def __init__(self,
-                 docker_host: str,
-                 docker_api_client: docker.APIClient,
-                 repository: str):
+    def __init__(self, docker_api_client: docker.APIClient, repository: str):
         super().__init__(repository)
-        if not docker_host:
-            self.docker_host = 'http+unix://%2Fvar%2Frun%2Fdocker.sock'
-        else:
-            self.docker_host = docker.utils.parse_host(docker_host)
         self.docker_api_client = docker_api_client
 
     def build(self, fileobj: BinaryIO, tag: str) -> Iterator[str]:
@@ -29,18 +19,17 @@ class LocalImages(Images):
         under testing. Going direct seems to be much faster.
         """
         tag = f'{self.repository}:{tag}'
-        with requests_unixsocket.monkeypatch():
-            return requests.post(
-                self.docker_host + '/build',
-                params={
-                    't': tag,
-                },
-                headers={
-                    'Content-Type': 'application/tar',
-                    'Content-Encoding': 'bz2',
-                },
-                data=fileobj,
-            )
+        return self.docker_api_client.post(
+            self.docker_api_client.base_url + '/build',
+            params={
+                't': tag,
+            },
+            headers={
+                'Content-Type': 'application/tar',
+                'Content-Encoding': 'bz2',
+            },
+            data=fileobj,
+        )
 
     def for_host(self, docker_url: str) -> 'LocalImages':
         new_docker_api_client = docker.APIClient(base_url=docker_url)

--- a/test/run
+++ b/test/run
@@ -12,6 +12,7 @@ PROJECT_NAME=plztest
 NETWORK="${PROJECT_NAME}_default"
 VOLUME="${PROJECT_NAME}_data"
 VOLUME_CONTAINER="${PROJECT_NAME}_data"
+CLI_BUILDER_IMAGE="${PROJECT_NAME}/cli-builder"
 CLI_IMAGE="${PROJECT_NAME}/cli"
 CLI_CONTAINER="${PROJECT_NAME}_cli"
 CONTROLLER_IMAGE="${PROJECT_NAME}/controller"
@@ -103,6 +104,7 @@ function controller_running {
 function build_cli {
   set -e
   info "Building the CLI..."
+  docker image build --quiet --target=builder --tag=$CLI_BUILDER_IMAGE cli
   docker image build --quiet --tag=$CLI_IMAGE cli
 }
 


### PR DESCRIPTION
This speeds up both building the CLI and controller, and the executions.

It also restructures a bunch of stuff in the `run` command to log timing information so I could figure out the above.

Turns out that the Python Docker client takes _ages_ to figure out authentication for building/pulling, which sucks. I would like to send them a patch upstream at some point but for now, we can just bypass it and use the Docker socket directly.