### PR TITLE
Test: Allow tests to run in parallel.

### DIFF
--- a/test/run
+++ b/test/run
@@ -80,7 +80,7 @@ function start_controller {
   info "Building the controller..."
   docker image build --quiet --tag=$CONTROLLER_IMAGE services/controller
 
-  if container_running $CONTROLLER_CONTAINER; then
+  if container_exists $CONTROLLER_CONTAINER; then
     warning "Controller already exists. Stopping..."
     stop_controller
   fi
@@ -232,13 +232,13 @@ function cleanup {
 }
 
 function stop_all_clis {
-  for container in $(docker container ls --quiet | grep "^${CLI_CONTAINER_PREFIX}"); do
+  for container in $(docker container ls --quiet --all --filter=name="${CLI_CONTAINER_PREFIX}"); do
     stop_cli $container
   done
 }
 
 function stop_cli {
-  if ! container_running $1; then
+  if ! container_exists $1; then
     return
   fi
   docker container stop $1 > /dev/null || :
@@ -247,13 +247,13 @@ function stop_cli {
 }
 
 function remove_all_volumes {
-  for volume in $(docker volume ls --quiet | grep "^${VOLUME_PREFIX}"); do
+  for volume in $(docker volume ls --quiet --filter=name="${VOLUME_PREFIX}"); do
     remove_volume $volume
   done
 }
 
 function remove_volume {
-  if container_running $1; then
+  if container_exists $1; then
     docker container kill $1 >& /dev/null || :
     docker container rm $1 > /dev/null
   fi
@@ -262,7 +262,7 @@ function remove_volume {
   fi
 }
 
-function container_running {
+function container_exists {
   docker container inspect $1 >& /dev/null
 }
 

--- a/test/run
+++ b/test/run
@@ -2,6 +2,7 @@
 
 set -e
 set -u
+set -o err_return
 set -o pipefail
 
 autoload -U colors && colors
@@ -76,7 +77,6 @@ else
 fi
 
 function start_controller {
-  set -e
   info "Building the controller..."
   docker image build --quiet --tag=$CONTROLLER_IMAGE services/controller
 
@@ -90,21 +90,18 @@ function start_controller {
 }
 
 function stop_controller {
-  set -e
   docker_compose stop
   docker_compose logs
   docker_compose down --volumes
 }
 
 function build_cli {
-  set -e
   info "Building the CLI..."
   docker image build --quiet --target=builder --tag=$CLI_BUILDER_IMAGE cli
   docker image build --quiet --tag=$CLI_IMAGE cli
 }
 
 function run_test {
-  set -e
   test=${test:a}
   echo
   info "Running ${test:t}..."
@@ -114,6 +111,7 @@ function run_test {
   else
     expected_exit_status=0
   fi
+  actual_exit_status_file=$(mktemp "${DATA_DIRECTORY}/plz-test-status.XXXXX")
   expected_logs="${test}/expected-logs"
   actual_logs=$(mktemp "${DATA_DIRECTORY}/plz-test-logs.XXXXX")
   expected_output_directory="${test}/expected-output"
@@ -121,14 +119,13 @@ function run_test {
   rm $actual_output_directory # It's been created as a file.
 
   start=$(date +%s)
-  run_cli $test $actual_logs $actual_output_directory \
-    && actual_exit_status=$? \
-    || actual_exit_status=$?
+  run_cli $test $actual_exit_status_file $actual_logs $actual_output_directory
   end=$(date +%s)
 
   info "Time taken: $((end - start))s."
 
   success=true
+  actual_exit_status=$(cat $actual_exit_status_file)
   if $bless; then
     if [[ $actual_exit_status -eq $expected_exit_status ]]; then
       info 'Blessing output...'
@@ -165,10 +162,10 @@ function run_test {
 }
 
 function run_cli {
-  set -e
   app_directory=${1:a}
-  logs_file=${2:a}
-  output_directory=${3:a}
+  exit_status_file=${2:a}
+  logs_file=${3:a}
+  output_directory=${4:a}
   test_config_file="${app_directory}/test.config.json"
   suffix=$RANDOM
   cli_container="${CLI_CONTAINER_PREFIX}_${suffix}"
@@ -217,36 +214,30 @@ function run_cli {
     |& redact_uuids \
     |& redact_instance_status \
     | tee $logs_file
-  exit_status=$(docker wait $cli_container)
+  docker wait $cli_container > $exit_status_file
   docker container rm $cli_container > /dev/null
 
   # Extract the output.
   docker container exec $volume sh -c '[ ! -d /data/output ]' \
     || docker container cp $volume:/data/output $output_directory
   remove_volume $volume
-
-  return $exit_status
 }
 
 function cleanup {
   exit_status=$?
-  set +e
   stop_all_clis
   stop_controller
   remove_all_volumes
-  set -e
   return $exit_status
 }
 
 function stop_all_clis {
-  set -e
   for container in $(docker container ls --quiet | grep "^${CLI_CONTAINER_PREFIX}"); do
     stop_cli $container
   done
 }
 
 function stop_cli {
-  set -e
   if ! container_running $1; then
     return
   fi
@@ -256,14 +247,12 @@ function stop_cli {
 }
 
 function remove_all_volumes {
-  set -e
   for volume in $(docker volume ls --quiet | grep "^${VOLUME_PREFIX}"); do
     remove_volume $volume
   done
 }
 
 function remove_volume {
-  set -e
   if container_running $1; then
     docker container kill $1 >& /dev/null || :
     docker container rm $1 > /dev/null
@@ -290,7 +279,7 @@ function redact_instance_status {
   grep -v '^Instance status: '
 }
 
-trap cleanup EXIT INT TERM
+trap 'exit_early=true; cleanup' EXIT INT TERM
 
 build_cli
 
@@ -305,8 +294,13 @@ export PLZ_HOST
 export PLZ_PORT
 
 success=true
+exit_early=false
 for test in $tests; do
   run_test $test || success=false
+  if $exit_early; then
+    success=false
+    break
+  fi
 done
 
 echo

--- a/test/run
+++ b/test/run
@@ -10,11 +10,10 @@ cd ${0:a:h:h}
 
 PROJECT_NAME=plztest
 NETWORK="${PROJECT_NAME}_default"
-VOLUME="${PROJECT_NAME}_data"
-VOLUME_CONTAINER="${PROJECT_NAME}_data"
+VOLUME_PREFIX="${PROJECT_NAME}_data_"
 CLI_BUILDER_IMAGE="${PROJECT_NAME}/cli-builder"
 CLI_IMAGE="${PROJECT_NAME}/cli"
-CLI_CONTAINER="${PROJECT_NAME}_cli"
+CLI_CONTAINER_PREFIX="${PROJECT_NAME}_cli_"
 CONTROLLER_IMAGE="${PROJECT_NAME}/controller"
 CONTROLLER_CONTAINER="${PROJECT_NAME}_controller_1"
 CONTROLLER_PORT=80
@@ -81,7 +80,7 @@ function start_controller {
   info "Building the controller..."
   docker image build --quiet --tag=$CONTROLLER_IMAGE services/controller
 
-  if controller_running; then
+  if container_running $CONTROLLER_CONTAINER; then
     warning "Controller already exists. Stopping..."
     stop_controller
   fi
@@ -97,10 +96,6 @@ function stop_controller {
   docker_compose down --volumes
 }
 
-function controller_running {
-  docker container inspect $CONTROLLER_CONTAINER >& /dev/null
-}
-
 function build_cli {
   set -e
   info "Building the CLI..."
@@ -110,20 +105,13 @@ function build_cli {
 
 function run_cli {
   set -e
-  if cli_running; then
-    warning "CLI container already exists. Stopping..."
-    stop_cli
-  fi
-
-  if volume_exists; then
-    warning "Volume already exists. Stopping..."
-    remove_volume
-  fi
-
   app_directory=${1:a}
   logs_file=${2:a}
   output_directory=${3:a}
   test_config_file="${app_directory}/test.config.json"
+  suffix=$RANDOM
+  cli_container="${CLI_CONTAINER_PREFIX}_${suffix}"
+  volume="${VOLUME_PREFIX}_${suffix}"
 
   args=()
   if [[ -f $test_config_file ]]; then
@@ -131,92 +119,102 @@ function run_cli {
   fi
 
   # Add the app directory to a Docker volume.
-  docker volume create $VOLUME > /dev/null
+  docker volume create $volume > /dev/null
   docker run \
-    --name=$VOLUME_CONTAINER \
+    --name=$volume \
     --detach \
     --interactive \
-    --volume=$VOLUME:/data \
+    --volume=$volume:/data \
     docker:stable-git \
     /bin/cat \
     > /dev/null
-  docker container cp $app_directory $VOLUME_CONTAINER:/data/app
+  docker container cp $app_directory $volume:/data/app
 
   # Initialize a Git repository to make excludes work.
   docker container run \
     --rm \
-    --volume=$VOLUME:/data \
+    --volume=$volume:/data \
     docker:stable-git \
     git init --quiet /data/app
 
   # Start the CLI process.
   docker container run \
-    --name=$CLI_CONTAINER \
+    --name=$cli_container \
     --detach \
     --network=$NETWORK \
     --env=PLZ_HOST=$PLZ_HOST \
     --env=PLZ_PORT=$PLZ_PORT \
     --env=PLZ_QUIET_BUILD=true \
     --workdir=/data/app \
-    --volume="${VOLUME}:/data" \
+    --volume="${volume}:/data" \
     $CLI_IMAGE \
-    run --output="/data/output" $args \
+    run --output=/data/output $args \
     > /dev/null
 
   # Capture the logs and exit status.
-  docker container logs --follow $CLI_CONTAINER |& redact_uuids |& redact_instance_status | tee $logs_file
-  exit_status=$(docker wait $CLI_CONTAINER)
-  docker container rm $CLI_CONTAINER > /dev/null
+  docker container logs --follow $cli_container |& redact_uuids |& redact_instance_status | tee $logs_file
+  exit_status=$(docker wait $cli_container)
+  docker container rm $cli_container > /dev/null
 
   # Extract the output.
-  docker container exec $VOLUME_CONTAINER sh -c '[ ! -d /data/output ]' \
-    || docker container cp $VOLUME_CONTAINER:/data/output $output_directory
-  remove_volume
+  docker container exec $volume sh -c '[ ! -d /data/output ]' \
+    || docker container cp $volume:/data/output $output_directory
+  remove_volume $volume
 
   return $exit_status
-}
-
-function stop_cli {
-  set -e
-  if ! cli_running; then
-    return
-  fi
-  docker container stop $CLI_CONTAINER > /dev/null || :
-  docker container rm $CLI_CONTAINER > /dev/null || :
-  info "CLI stopped."
-}
-
-function cli_running {
-  docker container inspect $CLI_CONTAINER >& /dev/null
 }
 
 function cleanup {
   exit_status=$?
   set +e
+  stop_all_clis
   stop_controller
-  stop_cli
-  remove_volume
-  docker network rm $NETWORK >& /dev/null || :
+  remove_all_volumes
+  set -e
   return $exit_status
+}
+
+function stop_all_clis {
+  set -e
+  for container in $(docker container ls --quiet | grep "^${CLI_CONTAINER_PREFIX}"); do
+    stop_cli $container
+  done
+}
+
+function stop_cli {
+  set -e
+  if ! container_running $1; then
+    return
+  fi
+  docker container stop $1 > /dev/null || :
+  docker container rm $1 > /dev/null || :
+  info "CLI stopped."
+}
+
+function remove_all_volumes {
+  set -e
+  for volume in $(docker volume ls --quiet | grep "^${VOLUME_PREFIX}"); do
+    remove_volume $volume
+  done
 }
 
 function remove_volume {
   set -e
-  if volume_container_exists; then
-    docker container kill $VOLUME_CONTAINER >& /dev/null || :
-    docker container rm $VOLUME_CONTAINER > /dev/null
-   fi
-  if volume_exists; then
-    docker volume rm $VOLUME > /dev/null
+  if container_running $1; then
+    docker container kill $1 >& /dev/null || :
+    docker container rm $1 > /dev/null
+  fi
+  if volume_exists $1; then
+    docker volume rm $1 > /dev/null
   fi
 }
 
-function volume_container_exists {
-  docker container inspect $VOLUME_CONTAINER >& /dev/null
+function container_running {
+  docker container inspect $1 >& /dev/null
 }
 
 function volume_exists {
-  docker volume inspect $VOLUME >& /dev/null
+  docker volume inspect $1 >& /dev/null
 }
 
 function redact_uuids {

--- a/test/run
+++ b/test/run
@@ -103,6 +103,67 @@ function build_cli {
   docker image build --quiet --tag=$CLI_IMAGE cli
 }
 
+function run_test {
+  set -e
+  test=${test:a}
+  echo
+  info "Running ${test:t}..."
+
+  if [[ -f "${test}/expected-status" ]]; then
+    expected_exit_status=$(cat "${test}/expected-status")
+  else
+    expected_exit_status=0
+  fi
+  expected_logs="${test}/expected-logs"
+  actual_logs=$(mktemp "${DATA_DIRECTORY}/plz-test-logs.XXXXX")
+  expected_output_directory="${test}/expected-output"
+  actual_output_directory=$(mktemp "${DATA_DIRECTORY}/plz-test-output.XXXXX")
+  rm $actual_output_directory # It's been created as a file.
+
+  start=$(date +%s)
+  run_cli $test $actual_logs $actual_output_directory \
+    && actual_exit_status=$? \
+    || actual_exit_status=$?
+  end=$(date +%s)
+
+  info "Time taken: $((end - start))s."
+
+  success=true
+  if $bless; then
+    if [[ $actual_exit_status -eq $expected_exit_status ]]; then
+      info 'Blessing output...'
+      cp $actual_logs $expected_logs
+      rm -rf $expected_output_directory
+      if [[ -e $actual_output_directory ]]; then
+        cp -R $actual_output_directory $expected_output_directory
+      fi
+      info 'Test blessed.'
+    else
+      error "Exited with a status code of ${actual_exit_status}."
+      success=false
+    fi
+  else
+    if [[ $actual_exit_status -ne $expected_exit_status ]]; then
+      success=false
+      error "Exited with a status code of ${actual_exit_status}."
+      error "Expected a status code of ${expected_exit_status}."
+      error 'Test failed.'
+    else
+      info 'Comparing output...'
+      if git diff --no-index $expected_logs $actual_logs && \
+         ( ! [[ -e $expected_output_directory ]] || \
+           git diff --no-index $expected_output_directory $actual_output_directory ); then
+        info 'Test passed.'
+      else
+        success=false
+        error 'Test failed.'
+      fi
+    fi
+  fi
+
+  $success
+}
+
 function run_cli {
   set -e
   app_directory=${1:a}
@@ -152,7 +213,10 @@ function run_cli {
     > /dev/null
 
   # Capture the logs and exit status.
-  docker container logs --follow $cli_container |& redact_uuids |& redact_instance_status | tee $logs_file
+  docker container logs --follow $cli_container \
+    |& redact_uuids \
+    |& redact_instance_status \
+    | tee $logs_file
   exit_status=$(docker wait $cli_container)
   docker container rm $cli_container > /dev/null
 
@@ -242,60 +306,7 @@ export PLZ_PORT
 
 success=true
 for test in $tests; do
-  test=${test:a}
-  echo
-  info "Running ${test:t}..."
-
-  if [[ -f "${test}/expected-status" ]]; then
-    expected_exit_status=$(cat "${test}/expected-status")
-  else
-    expected_exit_status=0
-  fi
-  expected_logs="${test}/expected-logs"
-  actual_logs=$(mktemp "${DATA_DIRECTORY}/plz-test-logs.XXXXX")
-  expected_output_directory="${test}/expected-output"
-  actual_output_directory=$(mktemp "${DATA_DIRECTORY}/plz-test-output.XXXXX")
-  rm $actual_output_directory # It's been created as a file.
-
-  start=$(date +%s)
-  run_cli $test $actual_logs $actual_output_directory \
-    && actual_exit_status=$? \
-    || actual_exit_status=$?
-  end=$(date +%s)
-
-  info "Time taken: $((end - start))s."
-
-  if $bless; then
-    if [[ $actual_exit_status -eq $expected_exit_status ]]; then
-      info "Blessing output..."
-      cp $actual_logs $expected_logs
-      rm -rf $expected_output_directory
-      if [[ -e $actual_output_directory ]]; then
-        cp -R $actual_output_directory $expected_output_directory
-      fi
-      info 'Test blessed.'
-    else
-      error "Exited with a status code of ${actual_exit_status}."
-      success=false
-    fi
-  else
-    if [[ $actual_exit_status -ne $expected_exit_status ]]; then
-      success=false
-      error "Exited with a status code of ${actual_exit_status}."
-      error "Expected a status code of ${expected_exit_status}."
-      error 'Test failed.'
-    else
-      info "Comparing output..."
-      if git diff --no-index $expected_logs $actual_logs && \
-         ( ! [[ -e $expected_output_directory ]] || \
-           git diff --no-index $expected_output_directory $actual_output_directory ); then
-        info 'Test passed.'
-      else
-        success=false
-        error 'Test failed.'
-      fi
-    fi
-  fi
+  run_test $test || success=false
 done
 
 echo

--- a/test/run
+++ b/test/run
@@ -56,10 +56,20 @@ fi
 # In "bless mode", instead of comparing the actual output against expected
 # output, we save the output.
 bless=false
-if [[ $# -gt 0 && $1 == '--bless' ]]; then
-  bless=true
-  shift
-fi
+# In "parallel mode", tests run in parallel.
+parallel=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --bless)
+      bless=true
+      shift ;;
+    --parallel)
+      parallel=true
+      shift ;;
+    *)
+      break
+  esac
+done
 
 if [[ $# -eq 0 ]]; then
   # Run all tests.
@@ -167,7 +177,7 @@ function run_cli {
   logs_file=${3:a}
   output_directory=${4:a}
   test_config_file="${app_directory}/test.config.json"
-  suffix=$RANDOM
+  suffix=$(slug ${app_directory:t})
   cli_container="${CLI_CONTAINER_PREFIX}_${suffix}"
   volume="${VOLUME_PREFIX}_${suffix}"
 
@@ -275,6 +285,10 @@ function redact_uuids {
   perl -pe '$| = 1; s/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/<UUID>/g'
 }
 
+function slug {
+  tr -C '[A-Za-z0-9_\n]' '_' <<< $1
+}
+
 function redact_instance_status {
   grep -v '^Instance status: '
 }
@@ -293,15 +307,25 @@ fi
 export PLZ_HOST
 export PLZ_PORT
 
-success=true
 exit_early=false
+success_file=$(mktemp "${DATA_DIRECTORY}/plz-test-success.XXXXX")
+pids=()
 for test in $tests; do
-  run_test $test || success=false
-  if $exit_early; then
-    success=false
-    break
+  if $parallel; then
+    (
+      test_output=$(run_test $test 2>&1) || rm -f $success_file
+      echo $test_output
+    ) & pids+=($!)
+  else
+    run_test $test || rm -f $success_file
   fi
 done
 
+if $parallel; then
+  for pid in $pids; do
+    wait $pid
+  done
+fi
+
 echo
-$success
+[[ -e $success_file ]]


### PR DESCRIPTION
It's worth noting that this doesn't actually work. The tests fail. This
has highlighted a number of weird quirks in our controller when one
test cleans up at just the wrong time. Containers go missing, 404s go
flying, calamity ensues.

I think these problems will be addressed by making harvesting a
background job, so we can leave it here and maybe switch to this mode as
the default when it's stable.

Here's an example of the errors we might get running tests in parallel:

    [2018-04-18 18:53:14,358] ERROR in app: Exception on /executions/bd30ac06-4339-11e8-8805-6bbc9a67228c/logs [GET]
    Traceback (most recent call last):
      File "/usr/local/lib/python3.6/site-packages/docker/api/client.py", line 225, in _raise_for_status
        response.raise_for_status()
      File "/usr/local/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
        raise HTTPError(http_error_msg, response=self)
    requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http+docker://localhost/v1.35/containers/f3819193e947894fa0e54a202ba9ac6ec45c6ee0cffc55a3fab25e4b15052c0b/json