### PR TITLE
CLI: Change the working directory inside the image to /src.

### DIFF
--- a/cli/src/plz/cli/run_execution_operation.py
+++ b/cli/src/plz/cli/run_execution_operation.py
@@ -130,7 +130,7 @@ class RunExecutionOperation(Operation):
                     dockerfile.write(step)
                     dockerfile.write('\n')
                 dockerfile.write(
-                    f'WORKDIR /app\n'
+                    f'WORKDIR /src\n'
                     f'COPY . ./\n'
                     f'CMD {self.configuration.command}\n'
                 )


### PR DESCRIPTION
We use `/src` in both our base images. Switching to `/app` at this point is problematic (and silly). It causes problems when running node.js-based software, as the dependencies are typically installed to `$PWD/node_modules`, and changing `$PWD` makes them unavailable.