### PR TITLE
CLI: Name the generated Dockerfile "plz.Dockerfile".

### DIFF
--- a/cli/src/plz/cli/run_execution_operation.py
+++ b/cli/src/plz/cli/run_execution_operation.py
@@ -120,7 +120,7 @@ class RunExecutionOperation(Operation):
 
     def capture_build_context(self) -> io.FileIO:
         context_dir = os.getcwd()
-        dockerfile_path = os.path.join(context_dir, 'Dockerfile')
+        dockerfile_path = os.path.join(context_dir, 'plz.Dockerfile')
         dockerfile_created = False
         try:
             with open(dockerfile_path, mode='x') as dockerfile:
@@ -141,7 +141,8 @@ class RunExecutionOperation(Operation):
                 gzip=True,
             )
         except FileExistsError as e:
-            raise CLIException('The directory cannot have a Dockerfile.', e)
+            raise CLIException(
+                    'The directory cannot have a plz.Dockerfile.', e)
         finally:
             if dockerfile_created:
                 os.remove(dockerfile_path)

--- a/services/controller/src/plz/controller/images/images_base.py
+++ b/services/controller/src/plz/controller/images/images_base.py
@@ -55,6 +55,7 @@ class Images(ABC):
             fileobj=fileobj,
             custom_context=True,
             encoding='bz2',
+            dockerfile='plz.Dockerfile',
             rm=True,
             tag=f'{self.repository}:{tag}',
             pull=True)


### PR DESCRIPTION
It's perfectly reasonable for the user to have a Dockerfile for some
other purpose. Expecting them to rename it is a bit rude.

We can't randomly generate a filename because that would affect the
final image hash, causing Docker image cache misses.