### PR TITLE
CLI: Move the HTTP error-handling to the Server class.

### DIFF
--- a/cli/src/plz/cli/main.py
+++ b/cli/src/plz/cli/main.py
@@ -1,10 +1,7 @@
 import argparse
+import os
 import sys
 from typing import Type
-
-import os
-import requests
-import urllib3.exceptions
 
 from plz.cli.configuration import Configuration, ValidationException
 from plz.cli.exceptions import CLIException, ExitWithStatusCodeException
@@ -81,14 +78,6 @@ def main(args=sys.argv[1:]):
         operation.run()
     except KeyboardInterrupt:
         log_error('Interrupted by the user.')
-        sys.exit(1)
-    except (ConnectionError,
-            requests.ConnectionError,
-            urllib3.exceptions.NewConnectionError):
-        log_error("We couldn't establish a connection to the server.")
-        sys.exit(1)
-    except requests.Timeout:
-        log_error('Our connection to the server timed out.')
         sys.exit(1)
     except CLIException as e:
         e.print(configuration)

--- a/cli/src/plz/cli/server.py
+++ b/cli/src/plz/cli/server.py
@@ -36,6 +36,3 @@ class Server:
     patch = functools.partialmethod(request, 'PATCH')
     post = functools.partialmethod(request, 'POST')
     put = functools.partialmethod(request, 'PUT')
-
-
-http_codes = requests.codes

--- a/cli/src/plz/cli/server.py
+++ b/cli/src/plz/cli/server.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Sequence
 
 import requests
@@ -8,10 +9,17 @@ from plz.cli.configuration import Configuration
 from plz.cli.exceptions import CLIException
 
 
-def _method(name: str):
-    def impl(self: 'Server', *path_segments: str, **kwargs) -> Response:
+class Server:
+    @staticmethod
+    def from_configuration(configuration: Configuration):
+        return Server(configuration.host, configuration.port)
+
+    def __init__(self, host: str, port: int):
+        self.prefix = f'http://{host}:{port}'
+
+    def request(self, method: str, *path_segments: str, **kwargs) -> Response:
         try:
-            return requests.request(name, self._url(path_segments), **kwargs)
+            return requests.request(method, self._url(path_segments), **kwargs)
         except (ConnectionError,
                 requests.ConnectionError,
                 urllib3.exceptions.NewConnectionError) as e:
@@ -21,24 +29,13 @@ def _method(name: str):
             raise CLIException(
                 'Our connection to the server timed out.') from e
 
-    return impl
-
-
-class Server:
-    @staticmethod
-    def from_configuration(configuration: Configuration):
-        return Server(configuration.host, configuration.port)
-
-    def __init__(self, host: str, port: int):
-        self.prefix = f'http://{host}:{port}'
-
-    delete = _method('DELETE')
-    get = _method('GET')
-    head = _method('HEAD')
-    options = _method('OPTIONS')
-    patch = _method('PATCH')
-    post = _method('POST')
-    put = _method('PUT')
+    delete = functools.partialmethod(request, 'DELETE')
+    get = functools.partialmethod(request, 'GET')
+    head = functools.partialmethod(request, 'HEAD')
+    options = functools.partialmethod(request, 'OPTIONS')
+    patch = functools.partialmethod(request, 'PATCH')
+    post = functools.partialmethod(request, 'POST')
+    put = functools.partialmethod(request, 'PUT')
 
     def _url(self, path_segments: Sequence[str]) -> str:
         return self.prefix + '/' + '/'.join(path_segments)

--- a/cli/src/plz/cli/server.py
+++ b/cli/src/plz/cli/server.py
@@ -1,5 +1,4 @@
 import functools
-from typing import Sequence
 
 import requests
 import urllib3
@@ -19,7 +18,8 @@ class Server:
 
     def request(self, method: str, *path_segments: str, **kwargs) -> Response:
         try:
-            return requests.request(method, self._url(path_segments), **kwargs)
+            url = self.prefix + '/' + '/'.join(path_segments)
+            return requests.request(method, url, **kwargs)
         except (ConnectionError,
                 requests.ConnectionError,
                 urllib3.exceptions.NewConnectionError) as e:
@@ -36,9 +36,6 @@ class Server:
     patch = functools.partialmethod(request, 'PATCH')
     post = functools.partialmethod(request, 'POST')
     put = functools.partialmethod(request, 'PUT')
-
-    def _url(self, path_segments: Sequence[str]) -> str:
-        return self.prefix + '/' + '/'.join(path_segments)
 
 
 http_codes = requests.codes

--- a/cli/src/plz/cli/server.py
+++ b/cli/src/plz/cli/server.py
@@ -1,14 +1,25 @@
 from typing import Sequence
 
 import requests
+import urllib3
 from requests import Response
 
 from plz.cli.configuration import Configuration
+from plz.cli.exceptions import CLIException
 
 
 def _method(name: str):
-    def impl(self, *path_segments: str, **kwargs) -> Response:
-        return requests.request(name, self._url(path_segments), **kwargs)
+    def impl(self: 'Server', *path_segments: str, **kwargs) -> Response:
+        try:
+            return requests.request(name, self._url(path_segments), **kwargs)
+        except (ConnectionError,
+                requests.ConnectionError,
+                urllib3.exceptions.NewConnectionError) as e:
+            raise CLIException(
+                "We couldn't establish a connection to the server.") from e
+        except (TimeoutError, requests.Timeout) as e:
+            raise CLIException(
+                'Our connection to the server timed out.') from e
 
     return impl
 

--- a/cli/test/test/plz/cli/server_test.py
+++ b/cli/test/test/plz/cli/server_test.py
@@ -7,6 +7,7 @@ from contextlib import closing
 import flask
 import requests
 
+from plz.cli.exceptions import CLIException
 from plz.cli.server import Server
 
 
@@ -58,6 +59,20 @@ class ServerTest(unittest.TestCase):
         response = server.get('one', 'two', 'three')
         self.assertEqual(response.status_code, requests.codes.ok)
         self.assertEqual(response.text, '123')
+
+    def test_handles_connection_errors(self):
+        server = Server(host=self.host, port=self.port + 1)
+        with self.assertRaises(CLIException) as cm:
+            server.get()
+        self.assertEqual(cm.exception.args[0],
+                         "We couldn't establish a connection to the server.")
+
+    def test_handles_timeouts(self):
+        server = Server(host=self.host, port=self.port)
+        with self.assertRaises(CLIException) as cm:
+            server.get(timeout=0.00001)
+        self.assertEqual(cm.exception.args[0],
+                         'Our connection to the server timed out.')
 
 
 def create_app():

--- a/cli/test/test/plz/cli/server_test.py
+++ b/cli/test/test/plz/cli/server_test.py
@@ -4,6 +4,7 @@ import socket
 import unittest
 from contextlib import closing
 
+# noinspection PyPackageRequirements
 import flask
 import requests
 


### PR DESCRIPTION
And then a bunch of refactoring in _server.py_ to make it simpler.