### PR TITLE
Controller: write tombstones for terminated instances

### DIFF
--- a/cli/src/plz/cli/run_execution_operation.py
+++ b/cli/src/plz/cli/run_execution_operation.py
@@ -2,10 +2,10 @@ import io
 import itertools
 import json
 import os
-import time
 from typing import Any, Callable, Optional, Tuple
 
 import requests
+import time
 
 from plz.cli import parameters
 from plz.cli.configuration import Configuration
@@ -194,6 +194,7 @@ class RunExecutionOperation(Operation):
         execution_spec = {
             'instance_type': configuration.instance_type,
             'user': configuration.user,
+            'project': configuration.project,
             'input_id': input_id,
             'docker_run_args': configuration.docker_run_args
         }
@@ -208,7 +209,11 @@ class RunExecutionOperation(Operation):
                 'execution_spec': execution_spec,
                 'start_metadata': {
                     'commit': commit,
-                    'configuration': configuration.as_dict()
+                    'configuration': {
+                        k: v for k, v in configuration.as_dict().items()
+                        # User and project are present in the execution spec
+                        if k not in {'user', 'project'}
+                    }
                 },
             })
         check_status(response, requests.codes.accepted)

--- a/services/controller/src/plz/controller/arbitrary_object_json_encoder.py
+++ b/services/controller/src/plz/controller/arbitrary_object_json_encoder.py
@@ -1,0 +1,17 @@
+import flask
+
+
+class ArbitraryObjectJSONEncoder(flask.json.JSONEncoder):
+    """
+    This encoder tries very hard to encode any kind of object. It uses the
+     object's ``__dict__`` property if the object itself is not encodable.
+    """
+    def default(self, o):
+        try:
+            return super().default(o)
+        except TypeError:
+            return o.__dict__
+
+
+def dumps_arbitrary_json(o) -> str:
+    return ArbitraryObjectJSONEncoder().encode(o)

--- a/services/controller/src/plz/controller/containers.py
+++ b/services/controller/src/plz/controller/containers.py
@@ -6,8 +6,11 @@ from typing import Dict, Iterator, List, Optional
 import dateutil.parser
 import docker
 import docker.errors
+import requests
 from docker.models.containers import Container
 from docker.types import Mount
+
+from plz.controller.exceptions import WorkerUnreachableException
 
 ContainerState = collections.namedtuple(
     'ContainerState',
@@ -105,6 +108,9 @@ class Containers:
                 self._CONTAINER_NAME_PREFIX + execution_id)
         except docker.errors.NotFound:
             return None
+        except requests.exceptions.ConnectionError:
+            log.exception('Connecting to worker')
+            raise WorkerUnreachableException(execution_id)
 
     @staticmethod
     def _is_container_id(container_id: str):

--- a/services/controller/src/plz/controller/db_storage.py
+++ b/services/controller/src/plz/controller/db_storage.py
@@ -11,13 +11,16 @@ class DBStorage(ABC):
             -> None:
         pass
 
+    @abstractmethod
     def retrieve_start_metadata(self, execution_id: str) -> dict:
         pass
 
-    def add_execution_id_for_user_and_project(
+    @abstractmethod
+    def add_finished_execution_id(
             self, user: str, project: str, execution_id: str) -> None:
         pass
 
-    def retrieve_execution_ids_for_user_and_project(
+    @abstractmethod
+    def retrieve_finished_execution_ids(
             self, user: str, project: str) -> Set[str]:
         pass

--- a/services/controller/src/plz/controller/exceptions.py
+++ b/services/controller/src/plz/controller/exceptions.py
@@ -1,3 +1,8 @@
+class ResponseHandledException(Exception):
+    def __init__(self, response_code):
+        self.response_code = response_code
+
+
 class JSONResponseException(Exception):
     def __init__(self, json_string: str):
         super().__init__(json_string)

--- a/services/controller/src/plz/controller/exceptions.py
+++ b/services/controller/src/plz/controller/exceptions.py
@@ -18,6 +18,6 @@ class WorkerUnreachableException(ResponseHandledException):
 
 
 class AbortedExecutionException(ResponseHandledException):
-    def __init__(self, forensics: dict):
+    def __init__(self, tombstone: object):
         super().__init__(response_code=requests.codes.gone)
-        self.forensics = forensics
+        self.tombstone = tombstone

--- a/services/controller/src/plz/controller/exceptions.py
+++ b/services/controller/src/plz/controller/exceptions.py
@@ -1,3 +1,6 @@
+import requests
+
+
 class ResponseHandledException(Exception):
     def __init__(self, response_code):
         self.response_code = response_code
@@ -6,3 +9,16 @@ class ResponseHandledException(Exception):
 class JSONResponseException(Exception):
     def __init__(self, json_string: str):
         super().__init__(json_string)
+
+
+class WorkerUnreachableException(ResponseHandledException):
+    def __init__(self, execution_id: str):
+        super().__init__(response_code=requests.codes.unavailable)
+        self.execution_id = execution_id
+
+
+class AbortedExecutionException(ResponseHandledException):
+    def __init__(self, forensics: dict):
+        super().__init__(response_code=requests.codes.gone)
+        self.forensics = forensics
+

--- a/services/controller/src/plz/controller/exceptions.py
+++ b/services/controller/src/plz/controller/exceptions.py
@@ -21,4 +21,3 @@ class AbortedExecutionException(ResponseHandledException):
     def __init__(self, forensics: dict):
         super().__init__(response_code=requests.codes.gone)
         self.forensics = forensics
-

--- a/services/controller/src/plz/controller/execution.py
+++ b/services/controller/src/plz/controller/execution.py
@@ -1,0 +1,64 @@
+from abc import ABC
+
+from plz.controller.execution_metadata import convert_measures_to_dict
+from plz.controller.instances.instance_base import InstanceProvider
+from plz.controller.results import ResultsStorage
+from plz.controller.results.results_base import Results
+
+
+class Execution(ABC):
+    def __init__(self, results: Results):
+        self.results = results
+        self.get_logs = self.results.get_logs
+        self.get_output_files_tarball = self.results.get_output_files_tarball
+        self.get_status = self.results.get_status
+
+    def get_measures(self) -> dict:
+        return convert_measures_to_dict(
+            self.results.get_measures_files_tarball())
+
+    def get_metadata(self) -> dict:
+        stored_metadata = self.results.get_stored_metadata()
+        # Measures are written by the workers in a specific directory and
+        # we store the tarball as to preserve the original data as much as
+        # possible. We don't store a structured representation as to avoid
+        # having two sources of truth. Instead, we recompute the structured
+        # representation from the tarball and add it to the metadata each time
+        # it's requested.
+        stored_metadata.update({'measures': self.get_measures()})
+        return stored_metadata
+
+
+class Executions:
+    def __init__(self, results_storage: ResultsStorage,
+                 instance_provider: InstanceProvider):
+        self.results_storage = results_storage
+        self.instance_provider = instance_provider
+
+    def get(self, execution_id: str):
+        with self.results_storage.get(execution_id) as results:
+            # We acquire the lock to make sure the results were successfully
+            # written. On return, the lock will be released but we know that,
+            # after written, the content of the results doesn't change
+            if results:
+                return _FinishedExecution(results)
+
+        instance = self.instance_provider.instance_for(execution_id)
+        if instance is None:
+            raise ExecutionNotFound(execution_id=execution_id)
+        return _OngoingExecution(instance)
+
+
+class ExecutionNotFound(Exception):
+    def __init__(self, execution_id):
+        self.execution_id = execution_id
+
+
+class _OngoingExecution(Execution):
+    def __init__(self, instance):
+        super().__init__(instance)
+
+
+class _FinishedExecution(Execution):
+    def __init__(self, results):
+        super().__init__(results)

--- a/services/controller/src/plz/controller/execution.py
+++ b/services/controller/src/plz/controller/execution.py
@@ -1,5 +1,8 @@
 from abc import ABC
 
+import requests
+
+from plz.controller.exceptions import ResponseHandledException
 from plz.controller.execution_metadata import convert_measures_to_dict
 from plz.controller.instances.instance_base import InstanceProvider
 from plz.controller.results import ResultsStorage
@@ -45,12 +48,13 @@ class Executions:
 
         instance = self.instance_provider.instance_for(execution_id)
         if instance is None:
-            raise ExecutionNotFound(execution_id=execution_id)
+            raise ExecutionNotFoundException(execution_id=execution_id)
         return _OngoingExecution(instance)
 
 
-class ExecutionNotFound(Exception):
+class ExecutionNotFoundException(ResponseHandledException):
     def __init__(self, execution_id):
+        super().__init__(response_code=requests.codes.not_found)
         self.execution_id = execution_id
 
 

--- a/services/controller/src/plz/controller/execution_metadata.py
+++ b/services/controller/src/plz/controller/execution_metadata.py
@@ -1,0 +1,63 @@
+import base64
+import io
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+from json import JSONDecodeError
+from typing import IO, Iterator, Optional, Tuple
+
+from werkzeug.contrib.iterio import IterIO
+
+from plz.controller.db_storage import DBStorage
+
+
+def convert_measures_to_dict(measures_tarball: Iterator[bytes]) -> dict:
+    measures_dict = {}
+    for path, file_content in _tar_iterator(measures_tarball):
+        content = file_content.read()
+        content_as_json = None
+        try:
+            content_as_json = json.load(io.BytesIO(content))
+        except JSONDecodeError or UnicodeDecodeError:
+            pass
+        if content_as_json is not None:
+            measures_dict[path] = content_as_json
+        else:
+            measures_dict[path] = {
+                'base64_bytes': base64.encodebytes(content).decode('ascii')
+            }
+    return measures_dict
+
+
+def compile_metadata_for_storage(
+        db_storage: DBStorage, execution_id: str,
+        finish_timestamp: int) -> dict:
+    start_metadata = db_storage.retrieve_start_metadata(execution_id)
+    return {**start_metadata,
+            'finish_timestamp': finish_timestamp}
+
+
+def _tar_iterator(tarball_bytes: Iterator[bytes]) \
+        -> Iterator[Tuple[str, Optional[IO]]]:
+    # The response is a tarball we need to extract into `output_dir`.
+    with tempfile.TemporaryFile() as tarball:
+        # `tarfile.open` needs to read from a real file, so we copy to one.
+        shutil.copyfileobj(IterIO(tarball_bytes), tarball)
+        # And rewind to the start.
+        tarball.seek(0)
+        tar = tarfile.open(fileobj=tarball)
+        for tarinfo in tar.getmembers():
+            # Drop the first segment, because it's just the name of the
+            # directory that was tarred up, and we don't care.
+            path_segments = tarinfo.name.split(os.sep)[1:]
+            if path_segments:
+                # Unfortunately we can't just pass `*path_segments`
+                # because `os.path.join` explicitly expects an argument
+                # for the first parameter.
+                path = os.path.join(path_segments[0], *path_segments[1:])
+                file_bytes = tar.extractfile(tarinfo.name)
+                # Not None for files and links
+                if file_bytes is not None:
+                    yield path, tar.extractfile(tarinfo.name)

--- a/services/controller/src/plz/controller/instances/aws/ec2_instance.py
+++ b/services/controller/src/plz/controller/instances/aws/ec2_instance.py
@@ -64,22 +64,11 @@ class EC2Instance(Instance):
             self._set_execution_id(
                 self.delegate.execution_id, max_idle_seconds)
 
-    def logs(self, since: Optional[int],
-             stdout: bool = True, stderr: bool = True) -> Iterator[bytes]:
-        return self.delegate.logs(
-            since=since, stdout=stdout, stderr=stderr)
-
     def is_up(self, is_instance_newly_created: bool):
         if not self._is_running():
             return False
         return self.images.can_pull(
             5 if is_instance_newly_created else 1)
-
-    def output_files_tarball(self) -> Iterator[bytes]:
-        return self.delegate.output_files_tarball()
-
-    def measures(self) -> dict:
-            return self.delegate.measures()
 
     def _dispose(self):
         self.client.terminate_instances(InstanceIds=[self._instance_id])
@@ -173,6 +162,20 @@ class EC2Instance(Instance):
     @property
     def _instance_id(self):
         return self.data['InstanceId']
+
+    def get_logs(self, since: Optional[int] = None, stdout: bool = True,
+                 stderr: bool = True) -> Iterator[bytes]:
+        return self.delegate.get_logs(
+            since=since, stdout=stdout, stderr=stderr)
+
+    def get_output_files_tarball(self) -> Iterator[bytes]:
+        return self.delegate.get_output_files_tarball()
+
+    def get_measures_files_tarball(self) -> Iterator[bytes]:
+        return self.delegate.get_measures_files_tarball()
+
+    def get_stored_metadata(self) -> dict:
+        return self.delegate.get_stored_metadata()
 
 
 def get_tag(instance_data, tag, default=None) -> Optional[str]:

--- a/services/controller/src/plz/controller/instances/aws/ec2_instance.py
+++ b/services/controller/src/plz/controller/instances/aws/ec2_instance.py
@@ -85,12 +85,8 @@ class EC2Instance(Instance):
     def _set_tags(self, tags):
         instance_id = self._instance_id
         self.client.create_tags(Resources=[instance_id], Tags=tags)
-        response = self.client.describe_instances(
-            Filters=[{'Name': 'instance-id',
-                      'Values': [instance_id]}])
-        self.data = [instance
-                     for reservation in response['Reservations']
-                     for instance in reservation['Instances']][0]
+        self.data = _describe_instances(
+            self.client, [('instance-id', instance_id)])[0]
 
     def get_max_idle_seconds(self) -> int:
         return int(get_tag(
@@ -147,17 +143,43 @@ class EC2Instance(Instance):
     def _is_running_and_free(self):
         if not self._is_running():
             return False
-        instances = get_running_aws_instances(
+        instances = get_aws_instances(
             self.client,
+            only_running=True,
             filters=[(f'tag:{EC2Instance.EXECUTION_ID_TAG}', ''),
                      ('instance-id', self._instance_id)])
         return len(instances) > 0
 
     def _is_running(self):
-        instances = get_running_aws_instances(
+        instances = get_aws_instances(
             self.client,
+            only_running=True,
             filters=[('instance-id', self._instance_id)])
         return len(instances) > 0
+
+    def get_resource_state(self) -> str:
+        instance = _describe_instances(
+            self.client,
+            filters=[('instance-id', self._instance_id)])[0]
+        return instance['State']['Name']
+
+    def delete_resource(self) -> None:
+        # It seems AWS doesn't allow to delete an instance. We set the group
+        # tag to empty so it won't be listed for a group anymore.
+        self._set_tags([{'Key': EC2Instance.GROUP_NAME_TAG,
+                         'Value': ''}])
+
+    def get_forensics(self) -> dict:
+        spot_requests = self.client.describe_spot_instance_requests(
+            Filters=[{'Name': 'instance-id',
+                      'Values': [self._instance_id]}])['SpotInstanceRequests']
+        if len(spot_requests) == 0:
+            return {}
+        if len(spot_requests) > 1:
+            log.warning('More than one spot request for instance '
+                        f'{self._instance_id}')
+        return {'SpotInstanceRequest': spot_requests[0],
+                'InstanceState': self.get_resource_state()}
 
     @property
     def _instance_id(self):
@@ -185,12 +207,16 @@ def get_tag(instance_data, tag, default=None) -> Optional[str]:
     return default
 
 
-def get_running_aws_instances(client, filters: [(str, str)]):
+def get_aws_instances(
+        client, filters: [(str, str)], only_running: bool) -> [dict]:
+    if only_running:
+        filters += [('instance-state-name', 'running')]
+    return _describe_instances(client, filters)
+
+
+def _describe_instances(client, filters) -> [dict]:
     new_filters = [{'Name': n, 'Values': [v]} for (n, v) in filters]
-    instance_state_filter = [{'Name': 'instance-state-name',
-                              'Values': ['running']}]
-    response = client.describe_instances(
-        Filters=new_filters + instance_state_filter)
+    response = client.describe_instances(Filters=new_filters)
     return [instance
             for reservation in response['Reservations']
             for instance in reservation['Instances']]

--- a/services/controller/src/plz/controller/instances/aws/ec2_instance.py
+++ b/services/controller/src/plz/controller/instances/aws/ec2_instance.py
@@ -174,11 +174,14 @@ class EC2Instance(Instance):
             Filters=[{'Name': 'instance-id',
                       'Values': [self._instance_id]}])['SpotInstanceRequests']
         if len(spot_requests) == 0:
-            return {}
-        if len(spot_requests) > 1:
+            spot_request_info = {}
+        elif len(spot_requests) > 1:
+            spot_request_info = {}
             log.warning('More than one spot request for instance '
                         f'{self._instance_id}')
-        return {'SpotInstanceRequest': spot_requests[0],
+        else:
+            spot_request_info = spot_requests[0]
+        return {'SpotInstanceRequest': spot_request_info,
                 'InstanceState': self.get_resource_state()}
 
     @property

--- a/services/controller/src/plz/controller/instances/docker.py
+++ b/services/controller/src/plz/controller/instances/docker.py
@@ -152,4 +152,4 @@ class DockerInstance(Instance):
             self.execution_id, Volumes.MEASURES_DIRECTORY_PATH)
 
     def get_stored_metadata(self) -> dict:
-        raise InstanceStillRunningException
+        raise InstanceStillRunningException(self.execution_id)

--- a/services/controller/src/plz/controller/instances/docker.py
+++ b/services/controller/src/plz/controller/instances/docker.py
@@ -84,6 +84,14 @@ class DockerInstance(Instance):
         # Doesn't make sense for local instances
         return 0
 
+    def get_resource_state(self) -> str:
+        # Docker is always running
+        return 'running'
+
+    def delete_resource(self) -> None:
+        # No underlying resource to delete
+        pass
+
     def get_execution_id(self) -> str:
         return self.execution_id
 
@@ -121,6 +129,9 @@ class DockerInstance(Instance):
                 raise CouldNotGetOutputException(
                     f'Couldn\'t read the results for {self.execution_id}')
             self._cleanup()
+
+    def get_forensics(self) -> dict:
+        return {}
 
     def _publish_results(self, results_storage: ResultsStorage,
                          finish_timestamp: int):

--- a/services/controller/src/plz/controller/instances/docker.py
+++ b/services/controller/src/plz/controller/instances/docker.py
@@ -9,10 +9,9 @@ from redis import StrictRedis
 
 from plz.controller.containers import ContainerState, Containers
 from plz.controller.images import Images
-from plz.controller.instances.instance_base import \
-    ExecutionInfo, Instance, Parameters
+from plz.controller.instances.instance_base import ExecutionInfo, Instance, \
+    InstanceStillRunningException, Parameters
 from plz.controller.results import ResultsStorage
-from plz.controller.results.local import convert_measures_to_dict
 from plz.controller.results.results_base import CouldNotGetOutputException
 from plz.controller.volumes import \
     VolumeDirectory, VolumeEmptyDirectory, VolumeFile, Volumes
@@ -67,24 +66,6 @@ class DockerInstance(Instance):
                             mounts=[Mount(source=volume.name,
                                           target=Volumes.VOLUME_MOUNT)],
                             docker_run_args=docker_run_args)
-
-    def logs(self, since: Optional[int], stdout: bool = True,
-             stderr: bool = True) -> Iterator[bytes]:
-        return self.containers.logs(self.execution_id,
-                                    since,
-                                    stdout=stdout,
-                                    stderr=stderr)
-
-    def output_files_tarball(self) -> Iterator[bytes]:
-        return self.containers.get_files(
-            self.execution_id, Volumes.OUTPUT_DIRECTORY_PATH)
-
-    def measures_files_tarball(self) -> Iterator[bytes]:
-        return self.containers.get_files(
-            self.execution_id, Volumes.MEASURES_DIRECTORY_PATH)
-
-    def measures(self) -> dict:
-        return convert_measures_to_dict(self.measures_files_tarball())
 
     def stop_execution(self):
         self.containers.stop(self.execution_id)
@@ -145,12 +126,30 @@ class DockerInstance(Instance):
                          finish_timestamp: int):
         results_storage.publish(
             self.get_execution_id(),
-            exit_status=self.exit_status(),
-            logs=self.logs(since=None),
-            output_tarball=self.output_files_tarball(),
-            measures_tarball=self.measures_files_tarball(),
+            exit_status=self.get_status().exit_status,
+            logs=self.get_logs(since=None),
+            output_tarball=self.get_output_files_tarball(),
+            measures_tarball=self.get_measures_files_tarball(),
             finish_timestamp=finish_timestamp)
 
     @property
     def _instance_id(self):
         return self.execution_id
+
+    def get_logs(self, since: Optional[int] = None, stdout: bool = True,
+                 stderr: bool = True) -> Iterator[bytes]:
+        return self.containers.logs(self.execution_id,
+                                    since,
+                                    stdout=stdout,
+                                    stderr=stderr)
+
+    def get_output_files_tarball(self) -> Iterator[bytes]:
+        return self.containers.get_files(
+            self.execution_id, Volumes.OUTPUT_DIRECTORY_PATH)
+
+    def get_measures_files_tarball(self) -> Iterator[bytes]:
+        return self.containers.get_files(
+            self.execution_id, Volumes.MEASURES_DIRECTORY_PATH)
+
+    def get_stored_metadata(self) -> dict:
+        raise InstanceStillRunningException

--- a/services/controller/src/plz/controller/instances/instance_base.py
+++ b/services/controller/src/plz/controller/instances/instance_base.py
@@ -5,10 +5,12 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from typing import Any, ContextManager, Dict, Iterator, List, Optional
 
+import requests
 from redis import StrictRedis
 from redis.lock import Lock
 
 from plz.controller.containers import ContainerMissingException, ContainerState
+from plz.controller.exceptions import ResponseHandledException
 from plz.controller.results.results_base import InstanceStatus, \
     InstanceStatusFailure, InstanceStatusRunning, InstanceStatusSuccess, \
     Results, ResultsStorage
@@ -213,8 +215,10 @@ class InstanceNotRunningException(Exception):
     pass
 
 
-class InstanceStillRunningException(Exception):
-    pass
+class InstanceStillRunningException(ResponseHandledException):
+    def __init__(self, execution_id):
+        super().__init__(response_code=requests.codes.conflict)
+        self.execution_id = execution_id
 
 
 class InstanceMissingStateException(Exception):

--- a/services/controller/src/plz/controller/instances/instance_base.py
+++ b/services/controller/src/plz/controller/instances/instance_base.py
@@ -122,9 +122,7 @@ class Instance(Results):
         pass
 
     def harvest(self, results_storage: ResultsStorage):
-        log.debug(f'Harvesting: {self.get_execution_id()}')
         with self._lock:
-            log.debug('After lock')
             resource_state = self.get_resource_state()
             execution_id = self.get_execution_id()
             if resource_state == 'terminated':

--- a/services/controller/src/plz/controller/instances/instance_base.py
+++ b/services/controller/src/plz/controller/instances/instance_base.py
@@ -141,7 +141,7 @@ class Instance(Results):
                             return
                     results_storage.write_tombstone(
                         execution_id,
-                        tombstone_dict={'forensics': self.get_forensics()})
+                        tombstone={'forensics': self.get_forensics()})
                 finally:
                     self.delete_resource()
 

--- a/services/controller/src/plz/controller/instances/localhost.py
+++ b/services/controller/src/plz/controller/instances/localhost.py
@@ -74,7 +74,10 @@ class Localhost(InstanceProvider):
     def push(self, image_tag: str):
         pass
 
-    def instance_iterator(self) \
+    def instance_iterator(self, only_running: bool) \
             -> Iterator[Instance]:
         return iter(self.instance_for(execution_id)
                     for execution_id in self.containers.execution_ids())
+
+    def get_forensics(self, execution_id) -> dict:
+        return {}

--- a/services/controller/src/plz/controller/main.py
+++ b/services/controller/src/plz/controller/main.py
@@ -90,16 +90,16 @@ def handle_chunked_input():
 @app.errorhandler(ResponseHandledException)
 def handle_exception(exception: ResponseHandledException):
     if isinstance(exception, WorkerUnreachableException):
-        exception = add_forensics(exception)
+        exception = maybe_add_forensics(exception)
     return jsonify(exception_type=type(exception).__name__,
                    **{k: v for k, v in exception.__dict__.items()
                       if k != 'response_code'}), \
         exception.response_code
 
 
-def add_forensics(exception: WorkerUnreachableException):
+def maybe_add_forensics(exception: WorkerUnreachableException) \
+        -> ResponseHandledException:
     forensics = instance_provider.get_forensics(exception.execution_id)
-    log.debug(f'forensics: {forensics}')
     spot_state = forensics.get(
         'SpotInstanceRequest', {}).get('State', None)
     # We know better now

--- a/services/controller/src/plz/controller/main.py
+++ b/services/controller/src/plz/controller/main.py
@@ -91,7 +91,7 @@ def handle_chunked_input():
 def handle_exception(exception: ResponseHandledException):
     if isinstance(exception, WorkerUnreachableException):
         exception = add_forensics(exception)
-    return jsonify(type=type(exception).__name__,
+    return jsonify(exception_type=type(exception).__name__,
                    **{k: v for k, v in exception.__dict__.items()
                       if k != 'response_code'}), \
         exception.response_code

--- a/services/controller/src/plz/controller/results/local.py
+++ b/services/controller/src/plz/controller/results/local.py
@@ -1,16 +1,16 @@
 import json
 import os
 import shutil
-from itertools import tee
 from typing import ContextManager, Iterator, Optional
 
 from redis import StrictRedis
 from redis.lock import Lock
 
 from plz.controller.db_storage import DBStorage
-from plz.controller.results.results_base \
-    import Results, ResultsContext, ResultsStorage, compile_metadata, \
-    convert_measures_to_dict
+from plz.controller.execution_metadata import compile_metadata_for_storage
+from plz.controller.results.results_base import InstanceStatus, \
+    InstanceStatusFailure, InstanceStatusSuccess, Results, ResultsContext, \
+    ResultsStorage
 
 LOCK_TIMEOUT = 60  # 1 minute
 CHUNK_SIZE = 1024 * 1024  # 1 MB
@@ -49,15 +49,16 @@ class LocalResultsStorage(ResultsStorage):
 
             write_bytes(paths.logs, logs)
             write_bytes(paths.output, output_tarball)
-            measures_tarball, measures_tarball_copy = tee(measures_tarball)
             write_bytes(paths.measures, measures_tarball)
-            metadata = compile_metadata(
-                self.db_storage, execution_id, finish_timestamp,
-                measures_tarball_copy)
+            metadata = compile_metadata_for_storage(
+                self.db_storage, execution_id, finish_timestamp)
             with open(paths.metadata, 'w') as metadata_file:
                 json.dump(metadata, metadata_file)
             with open(paths.finished_file, 'w') as _:  # noqa: F841 (unused)
                 pass
+            self.db_storage.add_finished_execution_id(
+                user=metadata['user'], project=metadata['project'],
+                execution_id=execution_id)
 
     def get(self, execution_id: str) -> ContextManager[Optional[Results]]:
         paths = Paths(self.directory, execution_id)
@@ -93,21 +94,27 @@ class LocalResults(Results):
     def __init__(self, paths: 'Paths'):
         self.paths = paths
 
-    def status(self) -> int:
+    def get_status(self) -> InstanceStatus:
         with open(self.paths.exit_status) as f:
-            return int(f.read())
+            status = int(f.read())
+        if status == 0:
+            return InstanceStatusSuccess()
+        else:
+            return InstanceStatusFailure(status)
 
-    def logs(self) -> Iterator[bytes]:
+    def get_logs(self, since: Optional[int] = None, stdout: bool = True,
+                 stderr: bool = True) -> Iterator[bytes]:
         return read_bytes(self.paths.logs)
 
-    def output_tarball(self) -> Iterator[bytes]:
+    def get_output_files_tarball(self) -> Iterator[bytes]:
         return read_bytes(self.paths.output)
 
-    def measures(self) -> dict:
-        return convert_measures_to_dict(read_bytes(self.paths.measures))
+    def get_measures_files_tarball(self) -> Iterator[bytes]:
+        return read_bytes(self.paths.measures)
 
-    def metadata(self) -> Iterator[bytes]:
-        return read_bytes(self.paths.metadata)
+    def get_stored_metadata(self) -> dict:
+        with open(self.paths.metadata, 'r') as metadata_file:
+            return json.load(metadata_file)
 
 
 class Paths:

--- a/services/controller/src/plz/controller/results/local.py
+++ b/services/controller/src/plz/controller/results/local.py
@@ -58,13 +58,13 @@ class LocalResultsStorage(ResultsStorage):
                 user=metadata['user'], project=metadata['project'],
                 execution_id=execution_id)
 
-    def write_tombstone(self, execution_id: str, tombstone_dict: dict) -> None:
+    def write_tombstone(self, execution_id: str, tombstone: object) -> None:
         paths = Paths(self.directory, execution_id)
         with self._lock(execution_id):
             if os.path.exists(paths.finished_file):
                 return
             _force_mk_empty_dir(paths.directory)
-            tombstone_json = dumps_arbitrary_json(tombstone_dict)
+            tombstone_json = dumps_arbitrary_json(tombstone)
             with open(paths.tombstone_file, 'w') as tombstone_file:
                 tombstone_file.write(tombstone_json)
             with open(paths.finished_file, 'w') as _:  # noqa: F841 (unused)
@@ -136,8 +136,8 @@ class LocalTombstone(Results):
 
     def _raise_aborted(self) -> Any:
         with open(self.paths.tombstone_file, 'r') as tombstone:
-            tombstone_dict = json.load(tombstone)
-        raise AbortedExecutionException(tombstone_dict)
+            tombstone_object = json.load(tombstone)
+        raise AbortedExecutionException(tombstone_object)
 
     def get_status(self) -> InstanceStatus:
         return self._raise_aborted()

--- a/services/controller/src/plz/controller/results/results_base.py
+++ b/services/controller/src/plz/controller/results/results_base.py
@@ -22,7 +22,7 @@ class ResultsStorage(ABC):
         pass
 
     @abstractmethod
-    def write_tombstone(self, execution_id: str, tombstone_dict: dict) -> None:
+    def write_tombstone(self, execution_id: str, tombstone: object) -> None:
         pass
 
     @abstractmethod

--- a/services/controller/src/plz/controller/results/results_base.py
+++ b/services/controller/src/plz/controller/results/results_base.py
@@ -22,6 +22,10 @@ class ResultsStorage(ABC):
         pass
 
     @abstractmethod
+    def write_tombstone(self, execution_id: str, tombstone_dict: dict) -> None:
+        pass
+
+    @abstractmethod
     def get(self, execution_id: str) -> ContextManager[Optional['Results']]:
         pass
 

--- a/services/controller/src/plz/controller/results/results_base.py
+++ b/services/controller/src/plz/controller/results/results_base.py
@@ -1,16 +1,6 @@
-import base64
-import io
-import json
 import logging
-import os
-import shutil
-import tarfile
-import tempfile
 from abc import ABC, abstractmethod
-from json import JSONDecodeError
-from typing import ContextManager, Iterator, Optional, Tuple, IO
-
-from werkzeug.contrib.iterio import IterIO
+from typing import ContextManager, Iterator, Optional
 
 from plz.controller.db_storage import DBStorage
 
@@ -40,80 +30,64 @@ class ResultsStorage(ABC):
         pass
 
 
-class Results:
+class Results(ABC):
     @abstractmethod
-    def status(self) -> int:
+    def get_status(self) -> 'InstanceStatus':
         pass
 
     @abstractmethod
-    def logs(self) -> Iterator[bytes]:
+    def get_logs(self, since: Optional[int] = None, stdout: bool = True,
+                 stderr: bool = True) -> Iterator[bytes]:
         pass
 
     @abstractmethod
-    def output_tarball(self) -> Iterator[bytes]:
+    def get_output_files_tarball(self) -> Iterator[bytes]:
         pass
 
     @abstractmethod
-    def measures(self) -> dict:
+    def get_measures_files_tarball(self) -> Iterator[bytes]:
         pass
 
     @abstractmethod
-    def metadata(self) -> Iterator[bytes]:
+    def get_stored_metadata(self) -> dict:
         pass
+
+
+class InstanceStatus(ABC):
+    def __init__(self,
+                 running: bool,
+                 success: Optional[bool],
+                 exit_status: Optional[int]):
+        self.running = running
+        self.success = success
+        self.exit_status = exit_status
+
+
+class InstanceStatusRunning(InstanceStatus):
+    def __init__(self):
+        super().__init__(
+            running=True,
+            success=None,
+            exit_status=None)
+
+
+class InstanceStatusSuccess(InstanceStatus):
+    def __init__(self):
+        super().__init__(
+            running=False,
+            success=True,
+            exit_status=0)
+
+
+class InstanceStatusFailure(InstanceStatus):
+    def __init__(self, exit_status: int):
+        super().__init__(
+            running=False,
+            success=False,
+            exit_status=exit_status)
 
 
 ResultsContext = ContextManager[Optional[Results]]
-
-
-def compile_metadata(
-        db_storage: DBStorage, execution_id: str, finish_timestamp: int,
-        measures_tarball: Iterator[bytes]):
-    start_metadata = db_storage.retrieve_start_metadata(execution_id)
-    return {**start_metadata,
-            'measures': convert_measures_to_dict(measures_tarball),
-            'finish_timestamp': finish_timestamp}
-
-
-def convert_measures_to_dict(measures_tarball: Iterator[bytes]) -> dict:
-    measures_dict = {}
-    for path, file_content in _tar_iterator(measures_tarball):
-        content = file_content.read()
-        content_as_json = None
-        try:
-            content_as_json = json.load(io.BytesIO(content))
-        except JSONDecodeError or UnicodeDecodeError:
-            pass
-        if content_as_json is not None:
-            measures_dict[path] = content_as_json
-        else:
-            measures_dict[path] = {
-                'base64_bytes': base64.encodebytes(content).decode('ascii')
-            }
-    return measures_dict
-
-
-def _tar_iterator(tarball_bytes: Iterator[bytes]) \
-        -> Iterator[Tuple[str, Optional[IO]]]:
-    # The response is a tarball we need to extract into `output_dir`.
-    with tempfile.TemporaryFile() as tarball:
-        # `tarfile.open` needs to read from a real file, so we copy to one.
-        shutil.copyfileobj(IterIO(tarball_bytes), tarball)
-        # And rewind to the start.
-        tarball.seek(0)
-        tar = tarfile.open(fileobj=tarball)
-        for tarinfo in tar.getmembers():
-            # Drop the first segment, because it's just the name of the
-            # directory that was tarred up, and we don't care.
-            path_segments = tarinfo.name.split(os.sep)[1:]
-            if path_segments:
-                # Unfortunately we can't just pass `*path_segments`
-                # because `os.path.join` explicitly expects an argument
-                # for the first parameter.
-                path = os.path.join(path_segments[0], *path_segments[1:])
-                file_bytes = tar.extractfile(tarinfo.name)
-                # Not None for files and links
-                if file_bytes is not None:
-                    yield path, tar.extractfile(tarinfo.name)
 
 
 class CouldNotGetOutputException(Exception):


### PR DESCRIPTION
Return information about the spot instance request and the instance state when the worker is unreachable, or when the instance is not running.

Generalise the logic "if there are results, get things from there, otherwise from get them from the instance" in an `Execution` class.