### PR TITLE
Persist redis db in the cache volume instead of a docker volume

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -31,9 +31,8 @@ services:
 
   redis:
     image: redis:4
-    entrypoint: redis-server
+    # We assume that 5 minutes it's a reasonable
+    # time as to dump the redis DB
+    entrypoint: redis-server --save 300 1
     volumes:
-      - redis_data:/data
-
-volumes:
-  redis_data: {}
+      - /cache/redis_data:/data

--- a/services/controller/playbook.yml
+++ b/services/controller/playbook.yml
@@ -78,9 +78,11 @@
 
             redis:
               image: redis:4
-              entrypoint: redis-server
+              # We assume that 5 minutes it's a reasonable
+              # time as to dump the redis DB
+              entrypoint: redis-server --save 300 1
               volumes:
-                - redis_data:/data
+                - /cache/redis_data:/data
 
           volumes:
             redis_data: {}

--- a/vars.mk
+++ b/vars.mk
@@ -7,4 +7,3 @@ endif
 CONFIG_FILE = $(SECRETS_DIR)/config.json
 
 AMI_TAG = 2018-06-18
-WORKER_AMI = plz-worker-$(AMI_TAG)


### PR DESCRIPTION
We can't trust the docker cache when changing AMIs