### PR TITLE
Controller: for images, recreate ECR and docker clients in each login

### DIFF
--- a/services/controller/src/plz/controller/images/ecr.py
+++ b/services/controller/src/plz/controller/images/ecr.py
@@ -73,6 +73,7 @@ class ECRImages(Images):
         # which suggests that the problem is with the state of the (clients
         # of the) controller.
         self.docker_api_client = self.docker_api_client_creator()
+        self.ecr_client = self.ecr_client_creator()
         authorization_token = self.ecr_client.get_authorization_token()
         authorization_data = authorization_token['authorizationData']
         encoded_token = authorization_data[0]['authorizationToken']

--- a/services/controller/src/plz/controller/images/ecr.py
+++ b/services/controller/src/plz/controller/images/ecr.py
@@ -31,7 +31,7 @@ class ECRImages(Images):
             return docker.APIClient(base_url=docker_url)
         return ECRImages(
             new_docker_api_client_creator,
-            self.ecr_client,
+            self.ecr_client_creator,
             self.registry,
             self.repository,
             self.login_validity_in_minutes)

--- a/services/controller/src/plz/controller/images/ecr.py
+++ b/services/controller/src/plz/controller/images/ecr.py
@@ -68,7 +68,10 @@ class ECRImages(Images):
                 return
         log.debug('Logging in to ECR')
         # Recreating the clients in each login, as otherwise over time we
-        # start noticing weird authentication errors
+        # start noticing weird authentication errors. The errors stop when
+        # we restart the controller (without restarting the docker daemon)
+        # which suggests that the problem is with the state of the (clients
+        # of the) controller.
         self.docker_api_client = self.docker_api_client_creator()
         authorization_token = self.ecr_client.get_authorization_token()
         authorization_data = authorization_token['authorizationData']

--- a/services/controller/src/plz/controller/images/ecr.py
+++ b/services/controller/src/plz/controller/images/ecr.py
@@ -14,8 +14,8 @@ log = logging.getLogger(__name__)
 
 class ECRImages(Images):
     def __init__(self,
-                 docker_api_client_creator: Callable[None, docker.APIClient],
-                 ecr_client_creator: Callable[None, Any],
+                 docker_api_client_creator: Callable[[], docker.APIClient],
+                 ecr_client_creator: Callable[[], Any],
                  registry: str,
                  repository: str,
                  login_validity_in_minutes: int):
@@ -27,9 +27,10 @@ class ECRImages(Images):
         self.login_validity_in_minutes = login_validity_in_minutes
 
     def for_host(self, docker_url: str) -> 'ECRImages':
-        new_docker_api_client = docker.APIClient(base_url=docker_url)
+        def new_docker_api_client_creator():
+            return docker.APIClient(base_url=docker_url)
         return ECRImages(
-            new_docker_api_client,
+            new_docker_api_client_creator,
             self.ecr_client,
             self.registry,
             self.repository,

--- a/services/controller/src/plz/controller/images/images_base.py
+++ b/services/controller/src/plz/controller/images/images_base.py
@@ -3,7 +3,7 @@ import json
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Callable, Iterator
 
 import docker
 
@@ -15,8 +15,11 @@ log = logging.getLogger(__name__)
 
 
 class Images(ABC):
-    def __init__(self, docker_api_client: docker.APIClient, repository: str):
-        self.docker_api_client = docker_api_client
+    def __init__(self,
+                 docker_api_client_creator: Callable[None, docker.APIClient],
+                 repository: str):
+        self.docker_api_client_creator = docker_api_client_creator
+        self.docker_api_client = docker_api_client_creator()
         self.repository = repository
 
     @staticmethod

--- a/services/controller/src/plz/controller/images/images_base.py
+++ b/services/controller/src/plz/controller/images/images_base.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 class Images(ABC):
     def __init__(self,
-                 docker_api_client_creator: Callable[None, docker.APIClient],
+                 docker_api_client_creator: Callable[[], docker.APIClient],
                  repository: str):
         self.docker_api_client_creator = docker_api_client_creator
         self.docker_api_client = docker_api_client_creator()

--- a/services/controller/src/plz/controller/images/local.py
+++ b/services/controller/src/plz/controller/images/local.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Callable, Iterator
 
 import docker
 
@@ -6,15 +6,18 @@ from plz.controller.images.images_base import Images
 
 
 class LocalImages(Images):
-    def __init__(self, docker_api_client: docker.APIClient, repository: str):
-        super().__init__(docker_api_client, repository)
+    def __init__(self,
+                 docker_api_client_creator: Callable[None, docker.APIClient],
+                 repository: str):
+        super().__init__(docker_api_client_creator, repository)
 
     def build(self, fileobj: BinaryIO, tag: str) -> Iterator[bytes]:
         return self._build(fileobj, tag)
 
     def for_host(self, docker_url: str) -> 'LocalImages':
-        new_docker_api_client = docker.APIClient(base_url=docker_url)
-        return LocalImages(new_docker_api_client, self.repository)
+        def new_docker_api_client_creator():
+            return docker.APIClient(base_url=docker_url)
+        return LocalImages(new_docker_api_client_creator, self.repository)
 
     def push(self, tag: str):
         pass

--- a/services/controller/src/plz/controller/images/local.py
+++ b/services/controller/src/plz/controller/images/local.py
@@ -7,7 +7,7 @@ from plz.controller.images.images_base import Images
 
 class LocalImages(Images):
     def __init__(self,
-                 docker_api_client_creator: Callable[None, docker.APIClient],
+                 docker_api_client_creator: Callable[[], docker.APIClient],
                  repository: str):
         super().__init__(docker_api_client_creator, repository)
 


### PR DESCRIPTION
Otherwise after some time we start seeing weird authentication errors.

The errors go off when the controller is restarted (without restarting the Docker daemon), which suggests that something is wrong with the state of the (clients of the) controller