### PR TITLE
Controller: fix worker setup

### DIFF
--- a/machines/ml/prepare.yml
+++ b/machines/ml/prepare.yml
@@ -29,6 +29,21 @@
     - name: Install awscli
       pip:
         name: awscli
+    # Need to restart after installing: in case the kernel changed, things
+    # can get messy for instance when installing the nvidia driver
+    # It seems there's no pre-made way to reboot in ansible. It doesn't seem
+    # to be a bad thing to do either:
+    # https://github.com/ansible/ansible/issues/14413
+    - name: Restart the system
+      shell: "sleep 5 && reboot"
+      async: 1
+      poll: 0
+    - name: Wait for the system to reboot
+      wait_for_connection:
+        connect_timeout: 20
+        sleep: 5
+        delay: 5
+        timeout: 60
 
 # Build packages
 - hosts: controller


### PR DESCRIPTION
- When creating the AMI, restart packer instance after updating the packages
- Do not execute startup.yml in workers.
It basically sets up a cache. In the worker we are discarding
the cache so it's useless. We want to implement some sort of
cache eventually but the right way to do it is to create snapshots
with /var/lib/docker dirs with the images, and attach them to workers
(having different stuff in the cache every time goes against
reproducibility, and user code in the images costs usually nothing to
transfer)