### PR TITLE
CLI: make the controller api (and only the api) available to the cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ dist
 # Terraform
 .terraform
 *.tfstate.backup
-
-# Make controller api available from the CLI
-cli/src/plz/controller

--- a/cli/src/plz/controller/api
+++ b/cli/src/plz/controller/api
@@ -1,0 +1,1 @@
+../../../../services/controller/src/plz/controller/api/

--- a/plz
+++ b/plz
@@ -15,16 +15,6 @@ if ! command -v pipenv > /dev/null; then
   exit 2
 fi
 
-# Create a symlink to the controller code from the CLI. This is needed
-# since, even if we add the controller code to the PYTHONPATH, python
-# doesn't merge both paths as to create the package plz (it just takes
-# the first plz root in the PYTHONPATH). The way setup.py works is by
-# merging the two directories, which we "emulate" with this symlink
-
-if [[ ! -a ${ROOT}/cli/src/plz/controller ]]; then
-  ln -s ${ROOT}/services/controller/src/plz/controller ${ROOT}/cli/src/plz/controller
-fi
-
 PYTHON="$(cd "${ROOT}/cli" && pipenv --venv)/bin/python"
 
 PYTHONPATH="${ROOT}/cli/src" "${PYTHON}" "${ROOT}/cli/src/plz/cli/main.py" "$@"


### PR DESCRIPTION
Previous to this there was a hacky hack to create a symlink
to the controller code if it didn't exist. This worked as to run
the `plz` script to execute the code directly, but was breaking
`make check` for the cli, as the pipenv for the cli lacked the
modules required by the controller. If we have a link to the
controller api instead, everything works fine.

Underlying all this is the fact that if there are several
paths to a module in the pythonpath, the python interpreter
will pick only one of them (as opposed to java). So we cannot
put the api in a directory outside the controller and the api code
under plz.controller.api (as we'd do in java) as only either the
controller or the api would be picked