### PR TITLE
Examples: use t3 instances instead of t2

### DIFF
--- a/examples/python/plz.config.json
+++ b/examples/python/plz.config.json
@@ -6,7 +6,7 @@
     "project": "trying-a-project",
     "command": ["python", "main.py", "600"],
     "input": "file://../data/python_example",
-    "instance_type": "t2.micro",
+    "instance_type": "t3.micro",
     "instance_max_idle_time_in_minutes": 2,
     "max_bid_price_in_dollars_per_hour": 0.5
 }

--- a/examples/pytorch/plz.config.json
+++ b/examples/pytorch/plz.config.json
@@ -6,7 +6,7 @@
     "project": "pytorch-mnist-example",
     "command": ["python", "main.py", "--verbose"],
     "input": "file://../data/mnist",
-    "instance_type": "t2.medium",
+    "instance_type": "t3.medium",
     "instance_max_idle_time_in_minutes": 5,
     "max_bid_price_in_dollars_per_hour": 1
 }


### PR DESCRIPTION
It seems you can't get t2 spot instances any more