### PR TITLE
Controller: earmark instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /cache
+/test_cache
 /secrets
 .envrc
 output

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -30,6 +30,10 @@ services:
           # than one hour, something is wrong with it and should be
           # killed
           instance_lock_timeout = 3600
+          # We assume that instances take at most 20 minutes to start
+          # an execution. Later than that they'll be considered idle for
+          # too long and disposed of accordingly
+          instance_max_startup_time_in_minutes = 20
         }
 
     volumes:

--- a/services/controller/config/_aws.conf
+++ b/services/controller/config/_aws.conf
@@ -38,4 +38,8 @@ assumptions = {
   # than one hour, something is wrong with it and should be
   # killed
   instance_lock_timeout = 3600
+  # We assume that instances take at most 20 minutes to start
+  # an execution. Later than that they'll be considered idle for
+  # too long and disposed of accordingly
+  instance_max_startup_time_in_minutes = 20
 }

--- a/services/controller/config/localserver.conf
+++ b/services/controller/config/localserver.conf
@@ -35,4 +35,8 @@ assumptions = {
   # than one hour, something is wrong with it and should be
   # killed
   instance_lock_timeout = 3600
+  # We assume that instances take at most 20 minutes to start
+  # an execution. Later than that they'll be considered idle for
+  # too long and disposed of accordingly
+  instance_max_startup_time_in_minutes = 20
 }

--- a/services/controller/playbook.yml
+++ b/services/controller/playbook.yml
@@ -69,6 +69,10 @@
                     # than one hour, something is wrong with it and should be
                     # killed
                     instance_lock_timeout = 3600
+                    # We assume that instances take at most 20 minutes to start
+                    # an execution. Later than that they'll be considered idle for
+                    # too long and disposed of accordingly
+                    instance_max_startup_time_in_minutes = 20
                   }
               ports:
                 - "{{ service_port }}:80"

--- a/services/controller/src/plz/controller/configuration.py
+++ b/services/controller/src/plz/controller/configuration.py
@@ -89,7 +89,9 @@ def _instance_provider_from(
             worker_security_group_names=config.get(
                 'instances.worker_security_group_names', []),
             use_public_dns=config.get('instances.use_public_dns', False),
-            instance_lock_timeout=config['assumptions.instance_lock_timeout'])
+            instance_lock_timeout=config['assumptions.instance_lock_timeout'],
+            instance_max_startup_time_in_minutes=
+            config['assumptions.instance_max_startup_time_in_minutes'])
     else:
         raise ValueError('Invalid instance provider.')
     return instance_provider

--- a/services/controller/src/plz/controller/configuration.py
+++ b/services/controller/src/plz/controller/configuration.py
@@ -90,8 +90,8 @@ def _instance_provider_from(
                 'instances.worker_security_group_names', []),
             use_public_dns=config.get('instances.use_public_dns', False),
             instance_lock_timeout=config['assumptions.instance_lock_timeout'],
-            instance_max_startup_time_in_minutes=
-            config['assumptions.instance_max_startup_time_in_minutes'])
+            instance_max_startup_time_in_minutes=config[
+                'assumptions.instance_max_startup_time_in_minutes'])
     else:
         raise ValueError('Invalid instance provider.')
     return instance_provider

--- a/services/controller/src/plz/controller/controller_impl.py
+++ b/services/controller/src/plz/controller/controller_impl.py
@@ -83,6 +83,8 @@ class ControllerImpl(Controller):
         start_metadata['previous_execution_id'] = previous_execution_id
         self.db_storage.store_start_metadata(execution_id, start_metadata)
 
+        self._set_user_last_execution_id(
+            execution_spec['user'], execution_id)
         yield {'id': execution_id}
 
         try:
@@ -100,8 +102,6 @@ class ControllerImpl(Controller):
             if instance is None:
                 yield {'error': 'Couldn\'t get an instance.'}
                 return
-            self._set_user_last_execution_id(
-                execution_spec['user'], execution_id)
         except Exception as e:
             self.log.exception('Exception running command.')
             yield {'error': str(e)}

--- a/services/controller/src/plz/controller/instances/aws/ec2_instance.py
+++ b/services/controller/src/plz/controller/instances/aws/ec2_instance.py
@@ -77,7 +77,8 @@ class EC2Instance(Instance):
                     f'{self.delegate.execution_id} as it\'s not '
                     f'free (executing [{self.get_execution_id()}] or '
                     f'locked ({not acquired}) '
-                    f'or earmarked for [{self._get_earmark()}])')
+                    f'or earmarked for [{self._get_earmark()}] or '
+                    f'not running)')
             self.images.pull(snapshot_id)
             self.delegate.run(command, snapshot_id, parameters, input_stream,
                               docker_run_args)

--- a/services/controller/src/plz/controller/instances/aws/ec2_instance.py
+++ b/services/controller/src/plz/controller/instances/aws/ec2_instance.py
@@ -21,14 +21,22 @@ class EC2Instance(Instance):
     ROOT = os.path.join(os.path.dirname(__file__), '..', '..', '..')
 
     # We find available instances by looking at those in which
-    # the Execution-Id tag is the empty string. Instances are
-    # started with an empty value for this tag, the tag is set
+    # the Execution-Id tag is the empty string and they are not earmarked (they
+    # haven't been started for a particular execution ID). Instances are
+    # started with an empty value for the execution ID, the tag is set
     # when the instance starts executing, and it's emptied again
-    # when the execution finishes
+    # when the execution finishes. Also, at start the Earmark-Execution-Id
+    # is set to the execution ID that the instance is being started for, so
+    # that it's not picked up when starting other executions. The
+    # earmark is set to empty when the Execution-Id tag is set. When an
+    # execution finishes, both the Execution-Id and the
+    # Earmark-Execution-Id tags are empty, and instances can be reused by
+    # other executions (or be disposed of by harvesting if the time has come)
     EXECUTION_ID_TAG = 'Plz:Execution-Id'
     GROUP_NAME_TAG = 'Plz:Group-Id'
     MAX_IDLE_SECONDS_TAG = 'Plz:Max-Idle-Seconds'
     IDLE_SINCE_TIMESTAMP_TAG = 'Plz:Idle-Since-Timestamp'
+    EARMARK_EXECUTION_ID_TAG = 'Plz:Earmark-Execution-Id'
 
     def __init__(self,
                  client,

--- a/services/controller/src/plz/controller/instances/aws/ec2_instance.py
+++ b/services/controller/src/plz/controller/instances/aws/ec2_instance.py
@@ -105,7 +105,12 @@ class EC2Instance(Instance):
             {'Key': EC2Instance.EXECUTION_ID_TAG,
              'Value': execution_id},
             {'Key': EC2Instance.MAX_IDLE_SECONDS_TAG,
-             'Value': str(max_idle_seconds)}
+             'Value': str(max_idle_seconds)},
+            # If we are setting the execution id, either we are freeing the
+            # instance or assigning to an execution. In both case we don't
+            # want the instance to be earmarked
+            {'Key': EC2Instance.EARMARK_EXECUTION_ID_TAG,
+             'Value': ''}
         ])
 
     def _set_tags(self, tags):

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -20,7 +20,7 @@ CONTROLLER_TESTS_CONTAINER="${PROJECT_NAME}_controller-tests_1"
 CONTROLLER_PORT=80
 
 TEST_DIRECTORY=${0:a:h}
-DATA_DIRECTORY="${PWD}/cache/test"
+DATA_DIRECTORY="${PWD}/test_cache/"
 
 autoload -U colors && colors
 


### PR DESCRIPTION
    # We find available instances by looking at those in which
    # the Execution-Id tag is the empty string and they are not earmarked (they
    # haven't been started for a particular execution ID). Instances are
    # started with an empty value for the execution ID, the tag is set
    # when the instance starts executing, and it's emptied again
    # when the execution finishes. Also, at start the Earmark-Execution-Id
    # is set to the execution ID that the instance is being started for, so
    # that it's not picked up when starting other executions. The
    # earmark is set to empty when the Execution-Id tag is set. When an
    # execution finishes, both the Execution-Id and the
    # Earmark-Execution-Id tags are empty, and instances can be reused by
    # other executions (or be disposed of by harvesting if the time has come)