### PR TITLE
Default to on-demand instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ The controller can be stopped at any time with:
 
 ### AWS configuration
 
+If you want to run the examples using the AWS instances, be aware that this has
+a cost. By default, Plz uses _t2.micro_ on-demand instances. You can find out
+how much these cost on the
+[AWS EC2 Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) page.
+
 To start a controller that talks to AWS, you'll need to first set up the AWS
 CLI:
 
@@ -347,11 +352,19 @@ well (for example, there's a power cut). You can always use `plz list` and
 remaining. For maximum assurance, we recommend checking the state of your
 instances in the AWS console.
 
-If you want to run the examples using the AWS instances, be aware that this has
-a cost. You can change the value of `"max_bid_price_in_dollars_per_hour": N` in
-`plz.config.json` to any value you like. Examples takes around 5 minutes to run.
-The value in the provided configs range from \$0.5/hour to \$2/hour (for
-GPU-powered machines).
+By default, Plz uses on-demand instances. In order to use spot instances,
+specify the following in your _plz.config.json_ file:
+
+```json
+{
+    ...
+    "instance_market_type": "spot",
+    "max_bid_price_in_dollars_per_hour": <price>
+}
+```
+
+The value in the example configuration files range from \$0.5/hour to \$2/hour
+(for GPU-powered machines).
 
 ## Examples
 

--- a/cli/src/plz/cli/configuration.py
+++ b/cli/src/plz/cli/configuration.py
@@ -83,7 +83,7 @@ def _validate_market_spec(configuration, errors, operation: Optional[str]):
             'In order to use spot instances, in your plz.config.json file '
             'please set `\n'
             '"max_bid_price_in_dollars_per_hour": N\n'
-            '` for some N (or set `"instance_market_type": "on-demand"`, '
+            '` for some N (or set `"instance_market_type": "on_demand"`, '
             'which will be more expensive than any bid price you use)')
     if configuration.instance_market_type == 'on_demand' and \
             configuration.max_bid_price_in_dollars_per_hour is not None:

--- a/cli/src/plz/cli/configuration.py
+++ b/cli/src/plz/cli/configuration.py
@@ -147,7 +147,7 @@ class Configuration:
             Property('use_emojis', type=bool, default=True),
             Property('workarounds', type=dict,
                      default={'docker_build_retries': 3}),
-            Property('instance_market_type', type=str, default='spot',
+            Property('instance_market_type', type=str, default='on_demand',
                      validations=[_validate_market_spec]),
             Property('instance_max_uptime_in_minutes',
                      type=Optional[int],

--- a/examples/python/plz.config.json
+++ b/examples/python/plz.config.json
@@ -8,5 +8,6 @@
     "input": "file://../data/python_example",
     "instance_type": "t3.micro",
     "instance_max_idle_time_in_minutes": 2,
+    "instance_market_type": "spot",
     "max_bid_price_in_dollars_per_hour": 0.5
 }

--- a/examples/pytorch/plz.config.json
+++ b/examples/pytorch/plz.config.json
@@ -8,5 +8,6 @@
     "input": "file://../data/mnist",
     "instance_type": "t3.medium",
     "instance_max_idle_time_in_minutes": 5,
+    "instance_market_type": "spot",
     "max_bid_price_in_dollars_per_hour": 1
 }

--- a/examples/pytorch/plz.cuda.config.json
+++ b/examples/pytorch/plz.cuda.config.json
@@ -8,6 +8,9 @@
     "input": "file://../data/mnist",
     "instance_type": "p2.xlarge",
     "instance_max_idle_time_in_minutes": 5,
+    "instance_market_type": "spot",
     "max_bid_price_in_dollars_per_hour": 2,
-    "docker_run_args": {"runtime": "nvidia"}
+    "docker_run_args": {
+        "runtime": "nvidia"
+    }
 }

--- a/services/controller/src/plz/controller/main.py
+++ b/services/controller/src/plz/controller/main.py
@@ -132,14 +132,7 @@ def run_execution_entrypoint():
     parameters = request.json['parameters']
     execution_spec = request.json['execution_spec']
     start_metadata = request.json['start_metadata']
-    instance_market_spec = request.json.get(
-        'instance_market_spec',
-        # TODO: delete this once people update their CLI
-        {
-            'instance_market_type': 'spot',
-            'max_bid_price_in_dollars_per_hour': 3,
-            'instance_max_idle_time_in_minutes': 30
-        })
+    instance_market_spec = request.json.get('instance_market_spec')
     parallel_indices_range = request.json.get('parallel_indices_range')
 
     @_json_stream

--- a/test/controller/src/utils.py
+++ b/test/controller/src/utils.py
@@ -37,6 +37,7 @@ def create_context_for_example(
         example_name)
     configuration = Configuration.load(example_dir)
     configuration.context_path = example_dir
+    configuration.instance_market_type = 'spot'
     # The default is None (by design, so that the user needs to specify it),
     # and it will break when running tests against a controller starting
     # AWS instances

--- a/test/run-end-to-end-test
+++ b/test/run-end-to-end-test
@@ -121,6 +121,7 @@ function run_cli {
     --env=PLZ_PORT=$PLZ_PORT \
     --env=PLZ_USER='plz-test' \
     --env=PLZ_PROJECT=$project_name \
+    --env=PLZ_INSTANCE_MARKET_TYPE=spot \
     --env=PLZ_MAX_BID_PRICE_IN_DOLLARS_PER_HOUR=0.5 \
     --env=PLZ_INSTANCE_MAX_UPTIME_IN_MINUTES=0 \
     --env=PLZ_QUIET_BUILD=true \


### PR DESCRIPTION
This means we don't have to specify the max bid price, which also means the CLI works for local runs without having to set this value for no reason.