### PR TITLE
start_local_controller: use --no-build for docker compose

### DIFF
--- a/start_local_controller
+++ b/start_local_controller
@@ -7,6 +7,6 @@ docker pull "prodoai/plz_controller:timestamp_$(cat STABLE_BUILD_TIMESTAMP)"
 BUILD_TIMESTAMP=$(cat STABLE_BUILD_TIMESTAMP) \
     REDIS_DUMP_EVERY_SECONDS=2 \
     LOG_LEVEL=${LOG_LEVEL:-WARNING} \
-    docker-compose up -d prebuilt_controller_localhost
+    docker-compose up -d --no-build prebuilt_controller_localhost
 
 docker-compose logs -f &


### PR DESCRIPTION
To be extra sure. Again, it was there for aws, not having it here was simply overlooking.