### PR TITLE
Controller: remove `if parallel_instances` logic from controller object

### DIFF
--- a/services/controller/src/plz/controller/controller_impl.py
+++ b/services/controller/src/plz/controller/controller_impl.py
@@ -19,9 +19,8 @@ from plz.controller.api.types import InputMetadata, JSONString
 from plz.controller.configuration import Dependencies
 from plz.controller.db_storage import DBStorage
 from plz.controller.execution import Executions
-from plz.controller.execution_composition import AtomicComposition, \
-    IndicesComposition
-from plz.controller.execution_metadata import enrich_start_metadata, is_atomic
+from plz.controller.execution_composition import ExecutionComposition
+from plz.controller.execution_metadata import is_atomic
 from plz.controller.images import Images
 from plz.controller.input_data import InputDataConfiguration
 from plz.controller.instances.instance_base import Instance, \
@@ -256,10 +255,14 @@ class ControllerImpl(Controller):
             previous_execution_id: Optional[str]) -> Iterator[dict]:
         execution_id = str(_get_execution_uuid())
 
-        all_metadatas = self._create_metadatas_for_all_executions(
+        composition = ExecutionComposition.from_parallel_indices_range(
+            parallel_indices_range, execution_id)
+
+        all_metadatas = composition.create_metadatas_for_all_executions(
             command, snapshot_id, parameters, instance_market_spec,
             execution_spec, start_metadata, parallel_indices_range,
-            indices_per_execution, previous_execution_id, execution_id)
+            indices_per_execution, previous_execution_id, execution_id,
+            execution_id_generator=_get_execution_uuid)
 
         for m in all_metadatas:
             self.db_storage.store_start_metadata(m['execution_id'], m)
@@ -286,71 +289,26 @@ class ControllerImpl(Controller):
 
             instances = [None for _ in statuses_generators]
 
-            yield from _assign_instances(instances, parallel_indices_range,
-                                         statuses_generators)
+            yield from _create_instances(
+                composition, instances, metadatas_to_run, statuses_generators)
 
-            if parallel_indices_range is None:
-                if instances[0] is None:
-                    yield {'error': 'Couldn\'t get an instance.'}
-                    return
-                composition = AtomicComposition(execution_id)
-            else:
-                indices_without_instance = [
-                    i for (i, instance) in enumerate(instances)
-                    if instance is None]
+            indices_without_instance = [
+                i for (i, instance) in enumerate(instances)
+                if instance is None]
 
-                if len(indices_without_instance) > 0:
-                    yield {'error': f'Couldn\'t get instances for indices: '
-                                    f'{indices_without_instance}'}
+            if len(indices_without_instance) > 0:
+                for i in indices_without_instance:
+                    status_prefix = _status_prefix(
+                        composition, metadatas_to_run[i])
+                    yield {
+                        'error': status_prefix + 'Couldn\'t get an instance'
+                    }
                     return
-                indices_to_compositions = {
-                    i: AtomicComposition(m['execution_id'])
-                    for m in metadatas_to_run
-                    for i in range(*m['index_range_to_run'])
-                }
-                composition = IndicesComposition(
-                    execution_id,
-                    indices_to_compositions=indices_to_compositions,
-                    tombstone_execution_ids=set())
+
             self.db_storage.store_execution_composition(composition)
         except Exception as e:
             self.log.exception('Exception running command.')
             yield {'error': str(e)}
-
-    def _create_metadatas_for_all_executions(
-            self, command: [str], snapshot_id: str, parameters: dict,
-            instance_market_spec: dict, execution_spec: dict,
-            start_metadata: dict,
-            parallel_indices_range: Optional[Tuple[int, int]],
-            indices_per_execution: Optional[int],
-            previous_execution_id: Optional[str],
-            execution_id: str) -> [dict]:
-        enriched_start_metadata = enrich_start_metadata(
-            execution_id, start_metadata, command, snapshot_id, parameters,
-            instance_market_spec, execution_spec, parallel_indices_range,
-            index_range_to_run=None,
-            indices_per_execution=indices_per_execution,
-            previous_execution_id=previous_execution_id)
-        metadatas = [enriched_start_metadata]
-        if parallel_indices_range is not None:
-            if indices_per_execution is None:
-                indices_per_execution = 1
-            for i in range(parallel_indices_range[0],
-                           parallel_indices_range[1],
-                           indices_per_execution):
-                this_exec_indices = min(
-                    indices_per_execution,
-                    parallel_indices_range[1] - parallel_indices_range[0] - i)
-                enriched_start_metadata = enrich_start_metadata(
-                    _get_execution_uuid(),
-                    start_metadata, command, snapshot_id, parameters,
-                    instance_market_spec, execution_spec,
-                    parallel_indices_range=None,
-                    index_range_to_run=(i, i + this_exec_indices),
-                    indices_per_execution=None,
-                    previous_execution_id=previous_execution_id)
-                metadatas.append(enriched_start_metadata)
-        return metadatas
 
 
 def _get_execution_uuid() -> str:
@@ -360,9 +318,10 @@ def _get_execution_uuid() -> str:
     return str(uuid.uuid1(node=random_node))
 
 
-def _assign_instances(
+def _create_instances(
+        composition: ExecutionComposition,
         instances: [Optional[Instance]],
-        parallel_indices_range: Optional[Tuple[int, int]],
+        metadatas_to_run: [dict],
         statuses_generators: [Iterator[dict]]) -> Iterator[dict]:
     # Whether was there a status update
     was_there_status = True
@@ -374,10 +333,17 @@ def _assign_instances(
                 continue
             was_there_status = True
             if 'message' in status:
-                if parallel_indices_range is not None:
-                    prefix = f'{i}: '
-                else:
-                    prefix = ''
-                yield {'status': prefix + status['message']}
+                status_prefix = _status_prefix(composition,
+                                               metadatas_to_run[i])
+                yield {'status': status_prefix + status['message']}
             if 'instance' in status:
                 instances[i] = status['instance']
+
+
+def _status_prefix(composition: ExecutionComposition, metadata: dict) -> str:
+    brief_description = \
+        composition.get_component_brief_description(metadata)
+    if brief_description != '':
+        return f'{brief_description}: '
+    else:
+        return ''

--- a/services/controller/src/plz/controller/controller_impl.py
+++ b/services/controller/src/plz/controller/controller_impl.py
@@ -3,7 +3,6 @@ import logging
 import os
 import random
 import uuid
-from copy import deepcopy
 from typing import BinaryIO, Iterator, List, Optional, Tuple
 
 import requests
@@ -22,6 +21,7 @@ from plz.controller.db_storage import DBStorage
 from plz.controller.execution import Executions
 from plz.controller.execution_composition import AtomicComposition, \
     IndicesComposition
+from plz.controller.execution_metadata import enrich_start_metadata
 from plz.controller.images import Images
 from plz.controller.input_data import InputDataConfiguration
 from plz.controller.instances.instance_base import Instance, \
@@ -320,7 +320,7 @@ class ControllerImpl(Controller):
             indices_per_execution: Optional[int],
             previous_execution_id: Optional[str],
             execution_id: str) -> [dict]:
-        enriched_start_metadata = _enrich_start_metadata(
+        enriched_start_metadata = enrich_start_metadata(
             execution_id, start_metadata, command, snapshot_id, parameters,
             instance_market_spec, execution_spec, parallel_indices_range,
             index_range_to_run=None,
@@ -338,7 +338,7 @@ class ControllerImpl(Controller):
                 this_exec_indices = min(
                     indices_per_execution,
                     parallel_indices_range[1] - parallel_indices_range[0] - i)
-                enriched_start_metadata = _enrich_start_metadata(
+                enriched_start_metadata = enrich_start_metadata(
                     _get_execution_uuid(),
                     start_metadata, command, snapshot_id, parameters,
                     instance_market_spec, execution_spec,
@@ -360,34 +360,6 @@ def _get_execution_uuid() -> str:
     # physical address (see Python uuid docs)
     random_node = random.getrandbits(48) | 0x010000000000
     return str(uuid.uuid1(node=random_node))
-
-
-def _enrich_start_metadata(
-        execution_id: str,
-        start_metadata: dict, command: [str], snapshot_id: str,
-        parameters: dict, instance_market_spec: dict, execution_spec: dict,
-        parallel_indices_range: Optional[Tuple[int, int]],
-        index_range_to_run: Optional[Tuple[int, int]],
-        indices_per_execution: Optional[int],
-        previous_execution_id: Optional[str]) -> dict:
-    enriched_start_metadata = deepcopy(start_metadata)
-    enriched_start_metadata['execution_id'] = execution_id
-    enriched_start_metadata['command'] = command
-    enriched_start_metadata['snapshot_id'] = snapshot_id
-    enriched_start_metadata['parameters'] = parameters
-    enriched_start_metadata['instance_market_spec'] = instance_market_spec
-    enriched_start_metadata['execution_spec'] = {
-        k: v for k, v in execution_spec.items()
-        if k not in {'user', 'project'}}
-    enriched_start_metadata['execution_spec']['index_range_to_run'] = \
-        index_range_to_run
-    enriched_start_metadata['user'] = execution_spec['user']
-    enriched_start_metadata['project'] = execution_spec['project']
-    enriched_start_metadata['parallel_indices_range'] = parallel_indices_range
-    enriched_start_metadata['index_range_to_run'] = index_range_to_run
-    enriched_start_metadata['indices_per_execution'] = indices_per_execution
-    enriched_start_metadata['previous_execution_id'] = previous_execution_id
-    return enriched_start_metadata
 
 
 def _assign_instances(

--- a/services/controller/src/plz/controller/execution_composition.py
+++ b/services/controller/src/plz/controller/execution_composition.py
@@ -139,28 +139,27 @@ class IndicesComposition(ExecutionComposition):
             indices_per_execution=indices_per_execution,
             previous_execution_id=previous_execution_id)
         metadatas = [enriched_start_metadata]
-        if parallel_indices_range is not None:
-            if indices_per_execution is None:
-                indices_per_execution = 1
-            for i in range(parallel_indices_range[0],
-                           parallel_indices_range[1],
-                           indices_per_execution):
-                this_exec_n_indices = min(
-                    indices_per_execution,
-                    parallel_indices_range[1] - parallel_indices_range[0] - i)
-                subexecution_id = execution_id_generator()
-                for j in range(this_exec_n_indices):
-                    self.assign_index(i + j,
-                                      AtomicComposition(subexecution_id))
-                enriched_start_metadata = enrich_start_metadata(
-                    subexecution_id,
-                    start_metadata, command, snapshot_id, parameters,
-                    instance_market_spec, execution_spec,
-                    parallel_indices_range=None,
-                    index_range_to_run=(i, i + this_exec_n_indices),
-                    indices_per_execution=None,
-                    previous_execution_id=None)
-                metadatas.append(enriched_start_metadata)
+        if indices_per_execution is None:
+            indices_per_execution = 1
+        for i in range(parallel_indices_range[0],
+                       parallel_indices_range[1],
+                       indices_per_execution):
+            this_exec_n_indices = min(
+                indices_per_execution,
+                parallel_indices_range[1] - parallel_indices_range[0] - i)
+            subexecution_id = execution_id_generator()
+            for j in range(this_exec_n_indices):
+                self.assign_index(i + j,
+                                  AtomicComposition(subexecution_id))
+            enriched_start_metadata = enrich_start_metadata(
+                subexecution_id,
+                start_metadata, command, snapshot_id, parameters,
+                instance_market_spec, execution_spec,
+                parallel_indices_range=None,
+                index_range_to_run=(i, i + this_exec_n_indices),
+                indices_per_execution=None,
+                previous_execution_id=None)
+            metadatas.append(enriched_start_metadata)
         return metadatas
 
     def assign_index(

--- a/services/controller/src/plz/controller/execution_composition.py
+++ b/services/controller/src/plz/controller/execution_composition.py
@@ -51,7 +51,7 @@ class ExecutionComposition(ABC):
         pass
 
     @abstractmethod
-    def get_component_brief_description(self, metadata: dict) -> '':
+    def get_component_brief_description(self, metadata: dict) -> str:
         pass
 
 
@@ -83,8 +83,8 @@ class AtomicComposition(ExecutionComposition):
             previous_execution_id=previous_execution_id)
         return [enriched_start_metadata]
 
-    def get_component_brief_description(self, metadata: dict) -> '':
-        return ', '.join(metadata['index_range_to_run'])
+    def get_component_brief_description(self, metadata: dict) -> str:
+        return ''
 
 
 class IndicesComposition(ExecutionComposition):
@@ -167,7 +167,7 @@ class IndicesComposition(ExecutionComposition):
             -> None:
         self.indices_to_compositions[index] = execution_composition
 
-    def get_component_brief_description(self, metadata: dict) -> '':
+    def get_component_brief_description(self, metadata: dict) -> str:
         return 'Indices: ' + (', '.join(
             str(n) for n in range(*metadata['index_range_to_run'])))
 

--- a/services/controller/src/plz/controller/execution_composition.py
+++ b/services/controller/src/plz/controller/execution_composition.py
@@ -1,9 +1,10 @@
 import os
 from abc import ABC, abstractmethod
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from typing import Any, Callable, Dict, Iterator, Optional, Set, Tuple
 
 from plz.controller.containers import Containers
+from plz.controller.execution_metadata import enrich_start_metadata
 from plz.controller.volumes import VolumeEmptyDirectory, Volumes
 
 
@@ -18,11 +19,39 @@ class ExecutionComposition(ABC):
     def __init__(self, execution_id: str):
         self.execution_id = execution_id
 
+    @staticmethod
+    def from_parallel_indices_range(
+            parallel_indices_range: Optional[Tuple[int, int]],
+            execution_id: str) -> 'ExecutionComposition':
+        if parallel_indices_range is None:
+            return AtomicComposition(execution_id)
+        else:
+            return IndicesComposition(
+                execution_id,
+                indices_to_compositions=None,
+                tombstone_execution_ids=None)
+
     @abstractmethod
     def to_jsonable_dict(self) -> Any:
         """
         Create a dict that we can turn into json
         """
+        pass
+
+    @abstractmethod
+    def create_metadatas_for_all_executions(
+                self, command: [str], snapshot_id: str, parameters: dict,
+                instance_market_spec: dict, execution_spec: dict,
+                start_metadata: dict,
+                parallel_indices_range: Optional[Tuple[int, int]],
+                indices_per_execution: Optional[int],
+                previous_execution_id: Optional[str],
+                execution_id: str,
+                execution_id_generator: Callable[[], str]) -> [dict]:
+        pass
+
+    @abstractmethod
+    def get_component_brief_description(self, metadata: dict) -> '':
         pass
 
 
@@ -37,6 +66,26 @@ class AtomicComposition(ExecutionComposition):
     def to_jsonable_dict(self):
         return {'execution_id': self.execution_id}
 
+    def create_metadatas_for_all_executions(
+            self, command: [str], snapshot_id: str, parameters: dict,
+            instance_market_spec: dict, execution_spec: dict,
+            start_metadata: dict,
+            parallel_indices_range: Optional[Tuple[int, int]],
+            indices_per_execution: Optional[int],
+            previous_execution_id: Optional[str],
+            execution_id: str,
+            execution_id_generator: Callable[[], str]) -> [dict]:
+        enriched_start_metadata = enrich_start_metadata(
+            execution_id, start_metadata, command, snapshot_id, parameters,
+            instance_market_spec, execution_spec, parallel_indices_range,
+            index_range_to_run=None,
+            indices_per_execution=indices_per_execution,
+            previous_execution_id=previous_execution_id)
+        return [enriched_start_metadata]
+
+    def get_component_brief_description(self, metadata: dict) -> '':
+        return ', '.join(metadata['index_range_to_run'])
+
 
 class IndicesComposition(ExecutionComposition):
     """
@@ -45,14 +94,19 @@ class IndicesComposition(ExecutionComposition):
 
     def __init__(
             self, execution_id: str,
-            indices_to_compositions: Dict[int, Optional[ExecutionComposition]],
-            tombstone_execution_ids: Set[str]):
+            indices_to_compositions: Optional[
+                Dict[int, Optional[ExecutionComposition]]],
+            tombstone_execution_ids: Optional[Set[str]]):
         super().__init__(execution_id)
         # A non-injective map with the sub-execution for a given index. If
         # there's no execution for a given index (for instance, it didn't
         # execute yet) the value is None
-        self.indices_to_compositions = indices_to_compositions
-        self.tombstone_execution_ids = tombstone_execution_ids
+        self.indices_to_compositions = indices_to_compositions \
+            if indices_to_compositions is not None \
+            else defaultdict(lambda: None)
+        self.tombstone_execution_ids = tombstone_execution_ids \
+            if tombstone_execution_ids is not None \
+            else {}
 
     def to_jsonable_dict(self):
         def jsonable_of_index(i: int):
@@ -68,6 +122,55 @@ class IndicesComposition(ExecutionComposition):
             },
             'tombstone_executions': list(self.tombstone_execution_ids)
         }
+
+    def create_metadatas_for_all_executions(
+            self, command: [str], snapshot_id: str, parameters: dict,
+            instance_market_spec: dict, execution_spec: dict,
+            start_metadata: dict,
+            parallel_indices_range: Optional[Tuple[int, int]],
+            indices_per_execution: Optional[int],
+            previous_execution_id: Optional[str],
+            execution_id: str,
+            execution_id_generator: Callable[[], str]) -> [dict]:
+        enriched_start_metadata = enrich_start_metadata(
+            execution_id, start_metadata, command, snapshot_id, parameters,
+            instance_market_spec, execution_spec, parallel_indices_range,
+            index_range_to_run=None,
+            indices_per_execution=indices_per_execution,
+            previous_execution_id=previous_execution_id)
+        metadatas = [enriched_start_metadata]
+        if parallel_indices_range is not None:
+            if indices_per_execution is None:
+                indices_per_execution = 1
+            for i in range(parallel_indices_range[0],
+                           parallel_indices_range[1],
+                           indices_per_execution):
+                this_exec_n_indices = min(
+                    indices_per_execution,
+                    parallel_indices_range[1] - parallel_indices_range[0] - i)
+                subexecution_id = execution_id_generator()
+                for j in range(this_exec_n_indices):
+                    self.assign_index(i + j,
+                                      AtomicComposition(subexecution_id))
+                enriched_start_metadata = enrich_start_metadata(
+                    subexecution_id,
+                    start_metadata, command, snapshot_id, parameters,
+                    instance_market_spec, execution_spec,
+                    parallel_indices_range=None,
+                    index_range_to_run=(i, i + this_exec_n_indices),
+                    indices_per_execution=None,
+                    previous_execution_id=None)
+                metadatas.append(enriched_start_metadata)
+        return metadatas
+
+    def assign_index(
+            self, index: int, execution_composition: ExecutionComposition) \
+            -> None:
+        self.indices_to_compositions[index] = execution_composition
+
+    def get_component_brief_description(self, metadata: dict) -> '':
+        return 'Indices: ' + (', '.join(
+            str(n) for n in range(*metadata['index_range_to_run'])))
 
 
 WorkerStartupConfig = namedtuple(

--- a/services/controller/src/plz/controller/execution_metadata.py
+++ b/services/controller/src/plz/controller/execution_metadata.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from copy import deepcopy
 from json import JSONDecodeError
 from typing import IO, Iterator, Optional, Tuple
 
@@ -74,3 +75,31 @@ def _tar_iterator(tarball_bytes: Iterator[bytes]) \
                 # Not None for files and links
                 if file_bytes is not None:
                     yield path, tar.extractfile(tarinfo.name)
+
+
+def enrich_start_metadata(
+        execution_id: str,
+        start_metadata: dict, command: [str], snapshot_id: str,
+        parameters: dict, instance_market_spec: dict, execution_spec: dict,
+        parallel_indices_range: Optional[Tuple[int, int]],
+        index_range_to_run: Optional[Tuple[int, int]],
+        indices_per_execution: Optional[int],
+        previous_execution_id: Optional[str]) -> dict:
+    enriched_start_metadata = deepcopy(start_metadata)
+    enriched_start_metadata['execution_id'] = execution_id
+    enriched_start_metadata['command'] = command
+    enriched_start_metadata['snapshot_id'] = snapshot_id
+    enriched_start_metadata['parameters'] = parameters
+    enriched_start_metadata['instance_market_spec'] = instance_market_spec
+    enriched_start_metadata['execution_spec'] = {
+        k: v for k, v in execution_spec.items()
+        if k not in {'user', 'project'}}
+    enriched_start_metadata['execution_spec']['index_range_to_run'] = \
+        index_range_to_run
+    enriched_start_metadata['user'] = execution_spec['user']
+    enriched_start_metadata['project'] = execution_spec['project']
+    enriched_start_metadata['parallel_indices_range'] = parallel_indices_range
+    enriched_start_metadata['index_range_to_run'] = index_range_to_run
+    enriched_start_metadata['indices_per_execution'] = indices_per_execution
+    enriched_start_metadata['previous_execution_id'] = previous_execution_id
+    return enriched_start_metadata

--- a/services/controller/src/plz/controller/execution_metadata.py
+++ b/services/controller/src/plz/controller/execution_metadata.py
@@ -11,8 +11,6 @@ from typing import IO, Iterator, Optional, Tuple
 
 from werkzeug.contrib.iterio import IterIO
 
-from plz.controller.db_storage import DBStorage
-
 
 def convert_measures_to_dict(measures_tarball: Iterator[bytes]) -> dict:
     measures_dict = {}
@@ -46,9 +44,11 @@ def _container_object_and_key_from_path(measures_dict: dict, path: str):
 
 
 def compile_metadata_for_storage(
-        db_storage: DBStorage, execution_id: str,
+        start_metadata: dict,
         finish_timestamp: int) -> dict:
-    start_metadata = db_storage.retrieve_start_metadata(execution_id)
+    # This function doesn't do much for now, but having it is a way to
+    # document that what we store as metadata is the start metadata plus
+    # other stuff
     return {**start_metadata,
             'finish_timestamp': finish_timestamp}
 

--- a/services/controller/src/plz/controller/execution_metadata.py
+++ b/services/controller/src/plz/controller/execution_metadata.py
@@ -103,3 +103,7 @@ def enrich_start_metadata(
     enriched_start_metadata['indices_per_execution'] = indices_per_execution
     enriched_start_metadata['previous_execution_id'] = previous_execution_id
     return enriched_start_metadata
+
+
+def is_atomic(start_metadata: dict) -> bool:
+    return start_metadata.get('parallel_indices_range', None) is None

--- a/services/controller/src/plz/controller/results/local.py
+++ b/services/controller/src/plz/controller/results/local.py
@@ -56,7 +56,8 @@ class LocalResultsStorage(ResultsStorage):
             log.debug(f'Writing logs and output for {execution_id}')
             write_bytes(paths.logs, logs)
             metadata = compile_metadata_for_storage(
-                self.db_storage, execution_id, finish_timestamp)
+                self.db_storage.retrieve_start_metadata(execution_id),
+                finish_timestamp)
             index_range_to_run = metadata['execution_spec'].get(
                 'index_range_to_run')
 


### PR DESCRIPTION
Now we have a single `if parallel_instance`, and it's not in the controller object :)