### PR TITLE
Controller: remove redundant copy of index_range_to_run

### DIFF
--- a/services/controller/src/plz/controller/execution_composition.py
+++ b/services/controller/src/plz/controller/execution_composition.py
@@ -168,8 +168,9 @@ class IndicesComposition(ExecutionComposition):
         self.indices_to_compositions[index] = execution_composition
 
     def get_component_brief_description(self, metadata: dict) -> str:
+        index_range_to_run = metadata['execution_spec']['index_range_to_run']
         return 'Indices: ' + (', '.join(
-            str(n) for n in range(*metadata['index_range_to_run'])))
+            str(n) for n in range(*index_range_to_run)))
 
 
 WorkerStartupConfig = namedtuple(

--- a/services/controller/src/plz/controller/execution_metadata.py
+++ b/services/controller/src/plz/controller/execution_metadata.py
@@ -99,7 +99,6 @@ def enrich_start_metadata(
     enriched_start_metadata['user'] = execution_spec['user']
     enriched_start_metadata['project'] = execution_spec['project']
     enriched_start_metadata['parallel_indices_range'] = parallel_indices_range
-    enriched_start_metadata['index_range_to_run'] = index_range_to_run
     enriched_start_metadata['indices_per_execution'] = indices_per_execution
     enriched_start_metadata['previous_execution_id'] = previous_execution_id
     return enriched_start_metadata

--- a/test/controller/src/test_parallel_indices.py
+++ b/test/controller/src/test_parallel_indices.py
@@ -99,7 +99,26 @@ class TestParallelIndices(unittest.TestCase):
             self._check_metadata_in_history(context, harvest_after_run, index,
                                             index_execution_id,
                                             n_indices_of_execution)
+            self._check_describe(context, index, index_execution_id,
+                                 n_indices_of_execution)
+        # Test describe for the whole execution
+        metadata = context.controller.describe_execution_entrypoint(
+            execution_id)['start_metadata']
+        range_from_describe = metadata['parallel_indices_range']
+        self.assertEqual(range_from_describe, [r for r in rainch])
         return context, execution_id
+
+    def _check_describe(self, context: TestingContext, index: int,
+                        index_execution_id: str,
+                        n_indices_of_execution: int):
+        metadata = context.controller.describe_execution_entrypoint(
+            index_execution_id)['start_metadata']
+        range_from_describe = metadata['execution_spec']['index_range_to_run']
+        # Check the range is two elements...
+        self.assertEqual(len(range_from_describe), 2)
+        self.assertEqual(range_from_describe[1] - range_from_describe[0],
+                         n_indices_of_execution)
+        self.assertIn(index, range(*range_from_describe))
 
     def _check_metadata_in_history(
             self, context: TestingContext, harvest_after_run: bool,


### PR DESCRIPTION
Now it's only inside execution_spec

Also, add test for describe