### PR TITLE
plz-output: improve performance and reliability

### DIFF
--- a/cli/src/plz/cli/controller_proxy.py
+++ b/cli/src/plz/cli/controller_proxy.py
@@ -105,7 +105,7 @@ class ControllerProxy(Controller):
             params={'path': path, 'index': index},
             stream=True)
         _check_status(response, requests.codes.ok)
-        # Read in chunks as to avoid several writes for long lifes
+        # Read in chunks as to avoid several writes for long files
         return _read_response_in_chunks(response)
 
     def get_measures(

--- a/cli/src/plz/cli/controller_proxy.py
+++ b/cli/src/plz/cli/controller_proxy.py
@@ -254,10 +254,10 @@ def _check_status(response: requests.Response, expected_status: int):
         raise RequestException(response)
 
 
-def _read_response_in_chunks(http_response: Response, chunked_read: bool) \
+def _read_response_in_chunks(http_response: Response) \
         -> Iterator[bytes]:
     while True:
-        bs = http_response.raw.read(1024 * 1024 if chunked_read else None)
+        bs = http_response.raw.read(1024 * 1024)
         if bs is None or len(bs) == 0:
             return
         yield bs

--- a/cli/src/plz/cli/controller_proxy.py
+++ b/cli/src/plz/cli/controller_proxy.py
@@ -257,7 +257,7 @@ def _check_status(response: requests.Response, expected_status: int):
 def _read_response_in_chunks(http_response: Response) \
         -> Iterator[bytes]:
     while True:
-        bs = http_response.raw.read(1024 * 1024)
+        bs = http_response.raw.read(_HTTP_RESPONSE_READ_CHUNK_SIZE)
         if bs is None or len(bs) == 0:
             return
         yield bs

--- a/services/controller/src/plz/controller/results/local.py
+++ b/services/controller/src/plz/controller/results/local.py
@@ -21,7 +21,6 @@ from plz.controller.results.results_base import InstanceStatus, \
 
 log = logging.getLogger(__name__)
 
-LOCK_TIMEOUT = 60  # 1 minute
 CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 
@@ -91,7 +90,7 @@ class LocalResultsStorage(ResultsStorage):
 
     def _lock(self, execution_id: str):
         lock_name = f'lock:{__name__}.{self.__class__.__name__}:{execution_id}'
-        lock = self.redis.lock(lock_name, timeout=LOCK_TIMEOUT)
+        lock = self.redis.lock(lock_name)
         return lock
 
     def is_finished(self, execution_id: str):


### PR DESCRIPTION
- Removed lock timeout. For outputs taking more than one minute to download, it was timing out and then failing when releasing the lock. Downloading in the meantime could cause getting partial output
- Improved how long responses are read from the CLI. It was reading small amounts at a time, implying a lot of writes, a huge waste of time. This might be due to a change in the underlying libraries, as we were having big outputs before and this wasn't a problem