### PR TITLE
Cli: fix context generation

### DIFF
--- a/cli/src/plz/cli/list_context_operation.py
+++ b/cli/src/plz/cli/list_context_operation.py
@@ -32,6 +32,7 @@ class ListContextOperation(Operation):
             excluded_paths=self.configuration.excluded_paths,
             included_paths=self.configuration.included_paths,
             exclude_gitignored_files=exclude_gitignored_files)
-        for p in sorted(list(
-                excluded_paths if self.excluded_paths else included_paths)):
-                print(p)
+        for p in sorted(
+                list(excluded_paths if self.excluded_paths else included_paths)
+        ):
+            print(p)

--- a/cli/src/plz/cli/list_context_operation.py
+++ b/cli/src/plz/cli/list_context_operation.py
@@ -1,6 +1,6 @@
 from plz.cli.configuration import Configuration
 from plz.cli.operation import Operation
-from plz.cli.snapshot import get_context_files, get_matching_excluded_paths
+from plz.cli.snapshot import get_included_and_excluded_files
 
 
 class ListContextOperation(Operation):
@@ -27,15 +27,11 @@ class ListContextOperation(Operation):
         exclude_gitignored_files = \
             self.configuration.exclude_gitignored_files
         context_path = self.configuration.context_path
-        matching_excluded_paths = get_matching_excluded_paths(
+        included_paths, excluded_paths = get_included_and_excluded_files(
             context_path=context_path,
             excluded_paths=self.configuration.excluded_paths,
             included_paths=self.configuration.included_paths,
             exclude_gitignored_files=exclude_gitignored_files)
-        if self.excluded_paths:
-            for p in sorted(list(set(matching_excluded_paths))):
+        for p in sorted(list(
+                excluded_paths if self.excluded_paths else included_paths)):
                 print(p)
-            return
-        for f in sorted(
-                get_context_files(context_path, matching_excluded_paths)):
-            print(f)

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -88,7 +88,7 @@ def get_included_and_excluded_files(
     excluded_files = set()
     for f in context_files:
         f_split = os.path.split(f)
-        f_prefixes = {os.path.join(*f_split[0:i])
+        f_prefixes = {os.path.join(*f_split[0:i + 1])
                       for i in range(1, len(f_split))}
         if len(f_prefixes.intersection(excluded_paths)) and (
                 not len(f_prefixes.intersection(included_paths))):

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -32,18 +32,15 @@ def capture_build_context(image: str, image_extensions: [str], command: [str],
                                  f'COPY . ./\n'
                                  f'CMD {json.dumps(command)}\n')
             os.chmod(dockerfile_path, 0o644)
-        print('Capture: Before get_matching_excluded')
         included_files, _ = get_included_and_excluded_files(
             context_path=context_path,
             excluded_paths=excluded_paths,
             included_paths=included_paths + [DOCKERFILE_NAME],
             exclude_gitignored_files=exclude_gitignored_files)
-        print('Capture: Before docker.utils.build.tar')
         build_context = docker.utils.build.create_archive(
             root=os.path.abspath(context_path),
             files=included_files,
             gzip=True)
-        print('Capture: After')
     finally:
         if dockerfile_created:
             os.remove(dockerfile_path)

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -32,88 +32,70 @@ def capture_build_context(image: str, image_extensions: [str], command: [str],
                                  f'COPY . ./\n'
                                  f'CMD {json.dumps(command)}\n')
             os.chmod(dockerfile_path, 0o644)
-        matching_excluded_paths = get_matching_excluded_paths(
+        print('Capture: Before get_matching_excluded')
+        included_files, _ = get_included_and_excluded_files(
             context_path=context_path,
             excluded_paths=excluded_paths,
-            included_paths=included_paths,
+            included_paths=included_paths + [DOCKERFILE_NAME],
             exclude_gitignored_files=exclude_gitignored_files)
-        build_context = docker.utils.build.tar(
-            path=context_path,
-            exclude=matching_excluded_paths,
-            gzip=True,
+        print('Capture: Before docker.utils.build.tar')
+        build_context = docker.utils.build.create_archive(
+            root=os.path.abspath(context_path),
+            files=included_files,
+            gzip=True
         )
+        print('Capture: After')
     finally:
         if dockerfile_created:
             os.remove(dockerfile_path)
     return build_context
 
 
-def get_matching_excluded_paths(context_path: [str], excluded_paths: [str],
-                                included_paths: [str],
-                                exclude_gitignored_files: bool) -> [str]:
+def get_included_and_excluded_files(
+        context_path: [str],
+        excluded_paths: [str],
+        included_paths: [str],
+        exclude_gitignored_files: bool) -> ({str}, {str}):
     def abs_path_glob_including_snapshot(p):
-        return os.path.abspath(os.path.join(context_path, p))
+        return glob2.iglob(os.path.abspath(os.path.join(context_path, p)),
+                           recursive=True,
+                           include_hidden=True)
 
-    def expand_if_dir(path):
-        if os.path.isdir(path):
-            # Return the dir as well as the files inside
-            return itertools.chain(
-                iter([path]),
-                glob2.iglob(os.path.join(path, '**'),
-                            recursive=True,
-                            include_hidden=True))
-        else:
-            return iter([path])
-
-    included_paths = set(
+    included_paths = {
         ip for p in included_paths
-        for ip in glob2.iglob(abs_path_glob_including_snapshot(p),
-                              recursive=True,
-                              include_hidden=True))
-    # Get the files inside the directories
-    included_paths = set(p for ip in included_paths for p in expand_if_dir(ip))
+        for ip in abs_path_glob_including_snapshot(p)
+    }
 
-    all_included_prefixes = set(
-        os.sep.join(ip.split(os.sep)[:n + 1]) for ip in included_paths
-        for n in range(len(ip.split(os.sep))))
+    excluded_paths = {
+        ip for p in excluded_paths
+        for ip in abs_path_glob_including_snapshot(p)
+    }
 
-    # Expand the globs
-    excluded_paths = [
-        ep for p in excluded_paths
-        for ep in glob2.iglob(abs_path_glob_including_snapshot(p),
-                              recursive=True,
-                              include_hidden=True)
-    ]
-
-    # Add the git ignored files
-    git_ignored_files = []
+    # Add the git ignored files if specified in the config
     # A value of None for exclude_gitignored_files means "exclude if git is
     # available"
     use_git = exclude_gitignored_files or (exclude_gitignored_files is None
                                            and is_git_present(context_path))
     if use_git:
-        git_ignored_files = [abs_path_glob_including_snapshot('.git')] + \
-                            get_ignored_git_files(context_path)
-    excluded_paths += git_ignored_files
+        excluded_paths.update(get_ignored_git_files(context_path))
+        excluded_paths.add(abs_path_glob_including_snapshot('.git'))
 
-    excluded_and_not_included_paths = []
-    for ep in excluded_paths:
-        if ep in all_included_prefixes:
-            excluded_and_not_included_paths += (
-                p for p in expand_if_dir(ep) if p not in all_included_prefixes)
+    def strip_context_path(f):
+        return f[len(os.path.abspath(context_path)) + len(os.sep):]
+
+    context_files = abs_path_glob_including_snapshot('**')
+    included_files = set()
+    excluded_files = set()
+    for f in context_files:
+        f_split = os.path.split(f)
+        f_prefixes = {os.path.join(*f_split[0:i])
+                      for i in range(1, len(f_split))}
+        if len(f_prefixes.intersection(excluded_paths)) and (
+                not len(f_prefixes.intersection(included_paths))):
+            excluded_files.add(strip_context_path(f))
         else:
-            excluded_and_not_included_paths.append(ep)
-
-    return [
-        p[len(os.path.abspath(context_path)) + 1:]
-        for p in excluded_and_not_included_paths
-    ]
-
-
-def get_context_files(context_path: str, matching_excluded_paths: [str]):
-    # Mimic what docker.utils.build.tar does
-    return docker.utils.build.exclude_paths(os.path.abspath(context_path),
-                                            matching_excluded_paths)
+            included_files.add(strip_context_path(f))
+    return included_files, excluded_files
 
 
 def submit_context_for_building(user: str, project: str,

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -84,7 +84,7 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
     excluded_files = set()
     for f in context_files:
         f_split = tuple(f.split(os.sep))
-        f_prefixes = {f_split[0:i] for i in range(0, len(f_split))}
+        f_prefixes = {f_split[0:i + 1] for i in range(0, len(f_split))}
         # A file matches a excluded path if one of it prefixes is a excluded
         # path. Same for included
         if len(f_prefixes.intersection(excluded_paths_tuples)) and (not len(

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -42,8 +42,7 @@ def capture_build_context(image: str, image_extensions: [str], command: [str],
         build_context = docker.utils.build.create_archive(
             root=os.path.abspath(context_path),
             files=included_files,
-            gzip=True
-        )
+            gzip=True)
         print('Capture: After')
     finally:
         if dockerfile_created:
@@ -51,24 +50,23 @@ def capture_build_context(image: str, image_extensions: [str], command: [str],
     return build_context
 
 
-def get_included_and_excluded_files(
-        context_path: [str],
-        excluded_paths: [str],
-        included_paths: [str],
-        exclude_gitignored_files: bool) -> ({str}, {str}):
+def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
+                                    included_paths: [str],
+                                    exclude_gitignored_files: bool
+                                    ) -> ({str}, {str}):
     def abs_path_glob_including_snapshot(p):
         return glob2.iglob(os.path.abspath(os.path.join(context_path, p)),
                            recursive=True,
                            include_hidden=True)
 
     included_paths = {
-        ip for p in included_paths
-        for ip in abs_path_glob_including_snapshot(p)
+        ip
+        for p in included_paths for ip in abs_path_glob_including_snapshot(p)
     }
 
     excluded_paths = {
-        ip for p in excluded_paths
-        for ip in abs_path_glob_including_snapshot(p)
+        ip
+        for p in excluded_paths for ip in abs_path_glob_including_snapshot(p)
     }
 
     # Add the git ignored files if specified in the config
@@ -88,10 +86,12 @@ def get_included_and_excluded_files(
     excluded_files = set()
     for f in context_files:
         f_split = os.path.split(f)
-        f_prefixes = {os.path.join(*f_split[0:i + 1])
-                      for i in range(1, len(f_split))}
-        if len(f_prefixes.intersection(excluded_paths)) and (
-                not len(f_prefixes.intersection(included_paths))):
+        f_prefixes = {
+            os.path.join(*f_split[0:i + 1])
+            for i in range(1, len(f_split))
+        }
+        if len(f_prefixes.intersection(excluded_paths)) and (not len(
+                f_prefixes.intersection(included_paths))):
             excluded_files.add(strip_context_path(f))
         else:
             included_files.add(strip_context_path(f))

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -1,4 +1,3 @@
-import itertools
 import json
 import os
 from typing import BinaryIO
@@ -74,10 +73,10 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
         excluded_paths_tuples.update(
             paths_as_tuples([get_ignored_git_files(context_path)]))
         excluded_paths_tuples.update(
-            paths_as_tuples([abs_path_glob_including_snapshot('.git')]))
+            paths_as_tuples(abs_path_glob_including_snapshot('.git')))
 
-    def strip_context_path(f):
-        return f[len(os.path.abspath(context_path)) + len(os.sep):]
+    def strip_context_from_file(fil):
+        return fil[len(os.path.abspath(context_path)) + len(os.sep):]
 
     context_files = abs_path_glob_including_snapshot('**')
     included_files = set()

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -73,7 +73,7 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
         excluded_paths_tuples.update(
             paths_as_tuples([get_ignored_git_files(context_path)]))
         excluded_paths_tuples.update(
-            paths_as_tuples(abs_path_glob_including_snapshot('.git')))
+            paths_as_tuples([abs_path_glob_including_snapshot('.git')]))
 
     def strip_context_from_file(fil):
         return fil[len(os.path.abspath(context_path)) + len(os.sep):]
@@ -88,9 +88,9 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
         # path. Same for included
         if len(f_prefixes.intersection(excluded_paths_tuples)) and (not len(
                 f_prefixes.intersection(included_paths_tuples))):
-            excluded_files.add(strip_context_path(f))
+            excluded_files.add(strip_context_from_file(f))
         else:
-            included_files.add(strip_context_path(f))
+            included_files.add(strip_context_from_file(f))
     return included_files, excluded_files
 
 

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -83,10 +83,7 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
     excluded_files = set()
     for f in context_files:
         f_split = tuple(f.split(os.sep))
-        f_prefixes = {
-            f_split[0:i + 1]
-            for i in range(0, len(f_split))
-        }
+        f_prefixes = {f_split[0:i + 1] for i in range(0, len(f_split))}
         # A file matches a excluded path if one of it prefixes is a excluded
         # path. Same for included
         if len(f_prefixes.intersection(excluded_paths)) and (not len(

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -84,7 +84,7 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
     excluded_files = set()
     for f in context_files:
         f_split = tuple(f.split(os.sep))
-        f_prefixes = {f_split[0:i + 1] for i in range(0, len(f_split))}
+        f_prefixes = {f_split[0:i] for i in range(0, len(f_split))}
         # A file matches a excluded path if one of it prefixes is a excluded
         # path. Same for included
         if len(f_prefixes.intersection(excluded_paths_tuples)) and (not len(

--- a/cli/src/plz/cli/snapshot.py
+++ b/cli/src/plz/cli/snapshot.py
@@ -57,12 +57,12 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
                            include_hidden=True)
 
     included_paths = {
-        ip
+        tuple(ip.split(os.sep))
         for p in included_paths for ip in abs_path_glob_including_snapshot(p)
     }
 
     excluded_paths = {
-        ip
+        tuple(ip.split(os.sep))
         for p in excluded_paths for ip in abs_path_glob_including_snapshot(p)
     }
 
@@ -82,11 +82,13 @@ def get_included_and_excluded_files(context_path: [str], excluded_paths: [str],
     included_files = set()
     excluded_files = set()
     for f in context_files:
-        f_split = os.path.split(f)
+        f_split = tuple(f.split(os.sep))
         f_prefixes = {
-            os.path.join(*f_split[0:i + 1])
-            for i in range(1, len(f_split))
+            f_split[0:i + 1]
+            for i in range(0, len(f_split))
         }
+        # A file matches a excluded path if one of it prefixes is a excluded
+        # path. Same for included
         if len(f_prefixes.intersection(excluded_paths)) and (not len(
                 f_prefixes.intersection(included_paths))):
             excluded_files.add(strip_context_path(f))

--- a/test/end-to-end/source/gitignored-files/main.py
+++ b/test/end-to-end/source/gitignored-files/main.py
@@ -10,4 +10,4 @@ for file_name in [
 
 for path in ['file_managed_by_git_excluded', 'file_ignored_by_git', '.git/']:
     if os.path.exists(path):
-        raise Exception(f'File {file_name} shouldn\'t be here')
+        raise Exception(f'File {path} shouldn\'t be here')

--- a/test/end-to-end/source/gitignored-files/main.py
+++ b/test/end-to-end/source/gitignored-files/main.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
+import os
+
 for file_name in [
         'file_ignored_by_git_included_explicitly', 'file_managed_by_git'
 ]:
     with open(file_name) as f:
         print(f.read(), end='')
 
-for file_name in ['file_managed_by_git_excluded', 'file_ignored_by_git']:
-    try:
-        with open(file_name) as f:
-            raise Exception(f'File {file_name} shouldn\'t be here')
-    except FileNotFoundError:
-        pass
+for path in ['file_managed_by_git_excluded', 'file_ignored_by_git', '.git/']:
+    if os.path.exists(path):
+        raise Exception(f'File {file_name} shouldn\'t be here')


### PR DESCRIPTION
When computing included/excluded files we were using a utility
function from the docker libraries, but it's very powerful
(heavy pattern matching) and then too slow if you happen to
have many files (even if ignored) it was taking quite some
noticeable time.

The logic is now simple and we are using just python globs,
which should be easier for the user to play with as well,
in case they are debugging their exclude/include specs