### PR TITLE
Cli: temporarily restrict the version of urllib3

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -47,6 +47,8 @@ setup(
         'requests >= 2.20.0',
         # Current version of requests is incompatible with urllib3 1.25,
         # forcing it to be at most 1.24.2
+        # See issue https://github.com/prodo-ai/plz/issues/252
+        # and PR https://github.com/prodo-ai/plz/pull/251 
         'urllib3 >= 1.23, <= 1.24.2',
     ],
     extras_require={

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -45,9 +45,9 @@ setup(
         'prettytable >= 0.7.2',
         'python-dateutil >= 2.7.3',
         'requests >= 2.20.0',
-        'urllib3 >= 1.23',
-        # Current version of requests is incompatible with urllib3 1.25
-        'urllib3 <= 1.24.2',
+        # Current version of requests is incompatible with urllib3 1.25,
+        # forcing it to be at most 1.24.2
+        'urllib3 >= 1.23, <= 1.24.2',
     ],
     extras_require={
         'test': [

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -48,7 +48,7 @@ setup(
         # Current version of requests is incompatible with urllib3 1.25,
         # forcing it to be at most 1.24.2
         # See issue https://github.com/prodo-ai/plz/issues/252
-        # and PR https://github.com/prodo-ai/plz/pull/251 
+        # and PR https://github.com/prodo-ai/plz/pull/251
         'urllib3 >= 1.23, <= 1.24.2',
     ],
     extras_require={

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -46,6 +46,8 @@ setup(
         'python-dateutil >= 2.7.3',
         'requests >= 2.20.0',
         'urllib3 >= 1.23',
+        # Current version of requests is incompatible with urllib3 1.25
+        'urllib3 <= 1.24.2',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
The current version of requests doesn't support urllib3 1.25